### PR TITLE
chore(scripts): cross platform support for copy

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -63,7 +63,7 @@
   },
   "scripts": {
     "version": "node -p -e \"'export default \\'' + require('./package.json').version + '\\';'\" > src/version.js",
-    "copy:webworkers": "cp node_modules/cornerstone-wado-image-loader/dist/*.min.js* public",
+    "copy:webworkers": "cpx node_modules/cornerstone-wado-image-loader/dist/*.min.js* public",
     "start": "npm run copy:webworkers && node scripts/start.js",
     "build": "node scripts/build.js",
     "test": "node scripts/test.js --env=jsdom"
@@ -118,6 +118,7 @@
     "extends": "react-app"
   },
   "devDependencies": {
+    "cpx": "1.5.0",
     "worker-loader": "^2.0.0"
   }
 }


### PR DESCRIPTION
If my commit message is off, I'm sorry. I had to disable husky to commit. The current setup is unable to find `node` when running hooks.