### PR TITLE
feat: 🎸 CorerstoneTools 4.0 + vtk-js brush sync example

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-react-vtkjs-viewport:registry=https://registry.npmjs.org/
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/src/VTKViewport/createLabelPipeline.js
+++ b/src/VTKViewport/createLabelPipeline.js
@@ -53,11 +53,11 @@ export default function createLabelPipeline(
   labelMap.actor.setMapper(labelMap.mapper);
 
   // set up labelMap color and opacity mapping
-  labelMap.cfun.addRGBPoint(1, 0, 0, 1); // label '1' will be blue
-  labelMap.cfun.addRGBPoint(2, 1, 0, 0); // label '2' will be red
-  labelMap.cfun.addRGBPoint(3, 0, 1, 0); // label '3' will be green
+  labelMap.cfun.addRGBPoint(1, 1, 0, 0); // label '1' will be red
+  labelMap.cfun.addRGBPoint(2, 0, 1, 0); // label '2' will be green
+  labelMap.cfun.addRGBPoint(3, 0, 1, 1); // label '3' will be blue
   labelMap.ofun.addPoint(0, 0);
-  labelMap.ofun.addPoint(1, 0.5);
+  labelMap.ofun.addPoint(1, 0.9);
 
   labelMap.actor.getProperty().setRGBTransferFunction(0, labelMap.cfun);
   labelMap.actor.getProperty().setScalarOpacity(0, labelMap.ofun);


### PR DESCRIPTION
Refactor of: #26 after repo changes.

Sister to : cornerstonejs/react-cornerstone-viewport#39

Upgrade the example to use cornerstoneTools 4.0. Upgrade and fix the sync example.