### PR TITLE
refactor: 💡 Refactor API and View2D usage

### DIFF
--- a/examples/VTKBasicExample.js
+++ b/examples/VTKBasicExample.js
@@ -9,14 +9,15 @@ import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
 import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
 import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
 
+// The data here is read from an unscaled *.vti, so we translate our windowCenter.
 const PRESETS = {
   BONE: {
     windowWidth: 100,
-    windowCenter: 500 + 1024, // The data here is is unscaled, so we need to move our preset.
+    windowCenter: 500 + 1024,
   },
   HEAD: {
     windowWidth: 1000,
-    windowCenter: 300 + 1024, // The data here is unscaled, so we need to move our preset.
+    windowCenter: 300 + 1024,
   },
 };
 class VTKBasicExample extends Component {

--- a/examples/VTKBasicExample.js
+++ b/examples/VTKBasicExample.js
@@ -94,7 +94,6 @@ class VTKBasicExample extends Component {
             const { windowWidth, windowCenter } = voi;
             const levels = this.state.levels || {};
 
-            debugger;
             apis.forEach(api => {
               const renderWindow = api.genericRenderWindow.getRenderWindow();
 

--- a/examples/VTKCornerstonePaintingSyncExample.js
+++ b/examples/VTKCornerstonePaintingSyncExample.js
@@ -108,7 +108,7 @@ class VTKCornerstonePaintingSyncExample extends Component {
   };
 
   componentDidMount() {
-    this.components = {};
+    this.apis = [];
     this.cornerstoneElements = {};
 
     // Pre-retrieve the images for demo purposes
@@ -167,16 +167,6 @@ class VTKCornerstonePaintingSyncExample extends Component {
     });
   }
 
-  setVtkjsPortOrientation(api) {
-    const renderWindow = api.genericRenderWindow.getRenderWindow();
-    const istyle = renderWindow.getInteractor().getInteractorStyle();
-
-    istyle.setSliceNormal(0, 0, 1);
-    istyle.setViewUp(0, -1, 0);
-
-    renderWindow.render();
-  }
-
   onPaintEnd = strokeBuffer => {
     const element = this.cornerstoneElements[0];
     const enabledElement = cornerstone.getEnabledElement(element);
@@ -227,8 +217,8 @@ class VTKCornerstonePaintingSyncExample extends Component {
 
   rerenderAllVTKViewports = () => {
     // TODO: Find out why this is not quick to update either
-    Object.keys(this.components).forEach(viewportIndex => {
-      const renderWindow = this.components[
+    Object.keys(this.apis).forEach(viewportIndex => {
+      const renderWindow = this.apis[
         viewportIndex
       ].genericRenderWindow.getRenderWindow();
 
@@ -236,14 +226,14 @@ class VTKCornerstonePaintingSyncExample extends Component {
     });
   };
 
-  saveComponentReference = viewportIndex => {
-    return component => {
-      this.components[viewportIndex] = component;
+  saveApiReference = api => {
+    this.apis = [api];
 
-      const paintFilter = component.filters[0];
+    api.updateVOI(voi.windowWidth, voi.windowCenter);
 
-      paintFilter.setRadius(10);
-    };
+    const paintFilter = api.filters[0];
+
+    paintFilter.setRadius(10);
   };
 
   saveCornerstoneElements = viewportIndex => {
@@ -320,11 +310,8 @@ class VTKCornerstonePaintingSyncExample extends Component {
                 paintFilterLabelMapImageData={this.state.labelMapInputData}
                 painting={this.state.focusedWidgetId === 'PaintWidget'}
                 onPaintEnd={this.onPaintEnd}
-                initialOrientation
-                onCreated={api => {
-                  this.saveComponentReference(0);
-                  this.setVtkjsPortOrientation(api);
-                }}
+                orietnation={{ sliceNormal: [0, 0, 1], viewUp: [0, -1, 0] }}
+                onCreated={this.saveApiReference}
               />
             )}
           </div>

--- a/examples/VTKCornerstonePaintingSyncExample.js
+++ b/examples/VTKCornerstonePaintingSyncExample.js
@@ -310,7 +310,7 @@ class VTKCornerstonePaintingSyncExample extends Component {
                 paintFilterLabelMapImageData={this.state.labelMapInputData}
                 painting={this.state.focusedWidgetId === 'PaintWidget'}
                 onPaintEnd={this.onPaintEnd}
-                orietnation={{ sliceNormal: [0, 0, 1], viewUp: [0, -1, 0] }}
+                orientation={{ sliceNormal: [0, 0, 1], viewUp: [0, -1, 0] }}
                 onCreated={this.saveApiReference}
               />
             )}

--- a/examples/VTKCrosshairsExample.js
+++ b/examples/VTKCrosshairsExample.js
@@ -3,57 +3,11 @@ import { Component } from 'react';
 import {
   View2D,
   vtkInteractorStyleMPRCrosshairs,
-  vtkSVGWidgetManager,
   vtkSVGCrosshairsWidget,
 } from '@vtk-viewport';
 import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
 import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
 import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
-import vtkMatrixBuilder from 'vtk.js/Sources/Common/Core/MatrixBuilder';
-import vtkCoordinate from 'vtk.js/Sources/Rendering/Core/Coordinate';
-
-function getCrosshairCallbackForIndex(apis, index) {
-  return ({ worldPos }) => {
-    // Set camera focal point to world coordinate for linked views
-    apis.forEach((api, viewportIndex) => {
-      if (viewportIndex !== index) {
-        // We are basically doing the same as getSlice but with the world coordinate
-        // that we want to jump to instead of the camera focal point.
-        // I would rather do the camera adjustment directly but I keep
-        // doing it wrong and so this is good enough for now.
-        const renderWindow = api.genericRenderWindow.getRenderWindow();
-
-        const istyle = renderWindow.getInteractor().getInteractorStyle();
-        const sliceNormal = istyle.getSliceNormal();
-        const transform = vtkMatrixBuilder
-          .buildFromDegree()
-          .identity()
-          .rotateFromDirections(sliceNormal, [1, 0, 0]);
-
-        const mutatedWorldPos = worldPos.slice();
-        transform.apply(mutatedWorldPos);
-        const slice = mutatedWorldPos[0];
-
-        istyle.setSlice(slice);
-
-        renderWindow.render();
-      }
-
-      const renderer = api.genericRenderWindow.getRenderer();
-      const wPos = vtkCoordinate.newInstance();
-      wPos.setCoordinateSystemToWorld();
-      wPos.setValue(worldPos);
-
-      const displayPosition = wPos.getComputedDisplayValue(renderer);
-      const { svgWidgetManager } = api;
-      api.svgWidgets.crosshairsWidget.setPoint(
-        displayPosition[0],
-        displayPosition[1]
-      );
-      svgWidgetManager.render();
-    });
-  };
-}
 
 class VTKCrosshairsExample extends Component {
   state = {
@@ -96,58 +50,20 @@ class VTKCrosshairsExample extends Component {
     return api => {
       this.apis[viewportIndex] = api;
 
+      const apis = this.apis;
       const renderWindow = api.genericRenderWindow.getRenderWindow();
-      const renderer = api.genericRenderWindow.getRenderer();
-      const camera = renderer.getActiveCamera();
 
-      // TODO: This is a hacky workaround because disabling the vtkInteractorStyleMPRSlice is currently
-      // broken. The camera.onModified is never removed.
-      renderWindow
-        .getInteractor()
-        .getInteractorStyle()
-        .setVolumeMapper(null);
+      api.addSVGWidget(
+        vtkSVGCrosshairsWidget.newInstance(),
+        'crosshairsWidget'
+      );
 
       const istyle = vtkInteractorStyleMPRCrosshairs.newInstance();
 
-      renderWindow.getInteractor().setInteractorStyle(istyle);
-      istyle.setVolumeMapper(api.volumes[0]);
-
-      istyle.setCallback(
-        getCrosshairCallbackForIndex(this.apis, viewportIndex)
-      );
-
-      const svgWidgetManager = vtkSVGWidgetManager.newInstance();
-      svgWidgetManager.setRenderer(renderer);
-      svgWidgetManager.setScale(1);
-
-      const crosshairsWidget = vtkSVGCrosshairsWidget.newInstance();
-
-      svgWidgetManager.addWidget(crosshairsWidget);
-      svgWidgetManager.render();
-
-      api.svgWidgetManager = svgWidgetManager;
-      api.svgWidgets = {
-        crosshairsWidget,
-      };
-
-      switch (viewportIndex) {
-        default:
-        case 0:
-          //Axial
-          istyle.setSliceNormal(0, 0, 1);
-          istyle.setViewUp(0, -1, 0);
-          break;
-        case 1:
-          // sagittal
-          istyle.setSliceNormal(1, 0, 0);
-          istyle.setViewUp(0, 0, 1);
-          break;
-        case 2:
-          // Coronal
-          istyle.setSliceNormal(0, 1, 0);
-          istyle.setViewUp(0, 0, 1);
-          break;
-      }
+      api.setInteractorStyle({
+        istyle,
+        configuration: { apis, apiIndex: viewportIndex },
+      });
 
       renderWindow.render();
     };
@@ -169,15 +85,28 @@ class VTKCrosshairsExample extends Component {
         </div>
         <div className="row">
           <div className="col-xs-12 col-sm-6">
-            <View2D volumes={this.state.volumes} onCreated={this.storeApi(0)} />
+            <View2D
+              volumes={this.state.volumes}
+              onCreated={this.storeApi(2)}
+              orientation={{ sliceNormal: [0, 1, 0], viewUp: [0, 0, 1] }}
+            />
           </div>
           <div className="col-xs-12 col-sm-6">
-            <View2D volumes={this.state.volumes} onCreated={this.storeApi(1)} />
+            <View2D
+              volumes={this.state.volumes}
+              onCreated={this.storeApi(1)}
+              orientation={{ sliceNormal: [1, 0, 0], viewUp: [0, 0, 1] }}
+            />
           </div>
         </div>
+
         <div className="row">
           <div className="col-xs-12 col-sm-6">
-            <View2D volumes={this.state.volumes} onCreated={this.storeApi(2)} />
+            <View2D
+              volumes={this.state.volumes}
+              onCreated={this.storeApi(0)}
+              orientation={{ sliceNormal: [0, 0, 1], viewUp: [0, -1, 0] }}
+            />
           </div>
         </div>
       </>

--- a/examples/VTKMPRPaintingExample.js
+++ b/examples/VTKMPRPaintingExample.js
@@ -90,7 +90,7 @@ class VTKMPRPaintingExample extends Component {
   };
 
   componentDidMount() {
-    this.components = {};
+    this.apis = [];
 
     const reader = vtkHttpDataSetReader.newInstance({
       fetchGzip: true,
@@ -146,8 +146,8 @@ class VTKMPRPaintingExample extends Component {
   };
 
   setThresholdFromValue = threshold => {
-    Object.keys(this.components).forEach(viewportIndex => {
-      const paintFilter = this.components[viewportIndex].filters[0];
+    Object.keys(this.apis).forEach(viewportIndex => {
+      const paintFilter = this.apis[viewportIndex].filters[0];
 
       paintFilter.setVoxelFunc((bgValue, idx) => {
         return bgValue[0] > threshold;
@@ -174,9 +174,9 @@ class VTKMPRPaintingExample extends Component {
     this.rerenderAllViewports();
   };
 
-  saveComponentReference = viewportIndex => {
-    return component => {
-      this.components[viewportIndex] = component;
+  saveApiReference = viewportIndex => {
+    return api => {
+      this.apis[viewportIndex] = api;
 
       this.setThresholdFromValue(this.state.threshold);
     };
@@ -185,8 +185,8 @@ class VTKMPRPaintingExample extends Component {
   rerenderAllViewports = () => {
     // Update all render windows, since the automatic re-render might not
     // happen if the viewport is not currently using the painting widget
-    Object.keys(this.components).forEach(viewportIndex => {
-      const renderWindow = this.components[
+    Object.keys(this.apis).forEach(viewportIndex => {
+      const renderWindow = this.apis[
         viewportIndex
       ].genericRenderWindow.getRenderWindow();
 
@@ -274,7 +274,7 @@ class VTKMPRPaintingExample extends Component {
             paintFilterLabelMapImageData={
               this.state.paintFilterLabelMapImageData
             }
-            onCreated={this.saveComponentReference(0)}
+            onCreated={this.saveApiReference(0)}
             painting={this.state.focusedWidgetId === 'PaintWidget'}
           />
         </div>
@@ -287,7 +287,7 @@ class VTKMPRPaintingExample extends Component {
             paintFilterLabelMapImageData={
               this.state.paintFilterLabelMapImageData
             }
-            onCreated={this.saveComponentReference(1)}
+            onCreated={this.saveApiReference(1)}
             painting={this.state.focusedWidgetId === 'PaintWidget'}
           />
         </div>

--- a/examples/VTKMPRRotateExample.js
+++ b/examples/VTKMPRRotateExample.js
@@ -1,155 +1,35 @@
 import React from 'react';
 import { Component } from 'react';
-import {
-  View2D,
-  getImageData,
-  loadImageData,
-  vtkInteractorStyleMPRRotate,
-  EVENTS,
-} from '@vtk-viewport';
-import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
-import vtkColorMaps from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction/ColorMaps';
+import { View2D, vtkInteractorStyleMPRRotate } from '@vtk-viewport';
 import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
 import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
 import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
 import vtkOrientationMarkerWidget from 'vtk.js/Sources/Interaction/Widgets/OrientationMarkerWidget';
 import vtkAnnotatedCubeActor from 'vtk.js/Sources/Rendering/Core/AnnotatedCubeActor';
-import { api } from 'dicomweb-client';
+
 import cornerstoneWADOImageLoader from 'cornerstone-wado-image-loader';
 import './initCornerstone.js';
-import Constants from 'vtk.js/Sources/Rendering/Core/VolumeMapper/Constants.js';
-
-const { BlendMode } = Constants;
 
 window.cornerstoneWADOImageLoader = cornerstoneWADOImageLoader;
 
 //const url = 'http://localhost:44301/wadors'
 //const url = 'http://localhost:8080/dcm4chee-arc/aets/DCM4CHEE/rs'
-const url = 'https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs';
-const studyInstanceUID =
-  // '1.3.6.1.4.1.14519.5.2.1.2744.7002.271803936741289691489150315969';
-  '1.3.6.1.4.1.14519.5.2.1.2744.7002.373729467545468642229382466905';
-const ctSeriesInstanceUID =
-  // '1.3.6.1.4.1.14519.5.2.1.2744.7002.453958960749354309542907936863'
-  '1.3.6.1.4.1.14519.5.2.1.2744.7002.182837959725425690842769990419';
-const petSeriesInstanceUID =
-  '1.3.6.1.4.1.14519.5.2.1.2744.7002.117357550898198415937979788256';
-const searchInstanceOptions = {
-  studyInstanceUID,
-};
-
-const volumeData = [
-  {
-    slicePlaneNormal: [0, 0, 1],
-    sliceViewUp: [0, -1, 0],
-    horizontalRotation: 0,
-    verticalRotation: 0,
-    viewRotation: 0,
-  },
-  {
-    slicePlaneNormal: [1, 0, 0],
-    sliceViewUp: [0, 0, 1],
-    horizontalRotation: 0,
-    verticalRotation: 0,
-    viewRotation: 0,
-  },
-  {
-    slicePlaneNormal: [0, 1, 0],
-    sliceViewUp: [0, 0, 1],
-    horizontalRotation: 0,
-    verticalRotation: 0,
-    viewRotation: 0,
-  },
-];
-
-function createStudyImageIds(baseUrl, studySearchOptions) {
-  const SOP_INSTANCE_UID = '00080018';
-  const SERIES_INSTANCE_UID = '0020000E';
-
-  const client = new api.DICOMwebClient({ url });
-
-  return new Promise((resolve, reject) => {
-    client.retrieveStudyMetadata(studySearchOptions).then(instances => {
-      const imageIds = instances.map(metaData => {
-        const imageId =
-          `wadors:` +
-          baseUrl +
-          '/studies/' +
-          studyInstanceUID +
-          '/series/' +
-          metaData[SERIES_INSTANCE_UID].Value[0] +
-          '/instances/' +
-          metaData[SOP_INSTANCE_UID].Value[0] +
-          '/frames/1';
-
-        cornerstoneWADOImageLoader.wadors.metaDataManager.add(
-          imageId,
-          metaData
-        );
-
-        return imageId;
-      });
-
-      resolve(imageIds);
-    }, reject);
-  });
-}
-
-function loadDataset(imageIds, displaySetInstanceUid) {
-  return new Promise((resolve, reject) => {
-    const imageDataObject = getImageData(imageIds, displaySetInstanceUid);
-
-    loadImageData(imageDataObject).then(() => {
-      resolve(imageDataObject.vtkImageData);
-    });
-  });
-}
-
-function createActorMapper(imageData) {
-  const mapper = vtkVolumeMapper.newInstance();
-  mapper.setInputData(imageData);
-
-  const actor = vtkVolume.newInstance();
-  actor.setMapper(mapper);
-
-  return {
-    actor,
-    mapper,
-  };
-}
-
-function createCT2dPipeline(imageData) {
-  const { actor, mapper } = createActorMapper(imageData);
-  const cfun = vtkColorTransferFunction.newInstance();
-  /*
-    0: { description: 'Soft tissue', window: 400, level: 40 },
-  1: { description: 'Lung', window: 1500, level: -600 },
-  2: { description: 'Liver', window: 150, level: 90 },
-  3: { description: 'Bone', window: 2500, level: 480 },
-  4: { description: 'Brain', window: 80, level: 40 },*/
-  const preset = vtkColorMaps.getPresetByName('Grayscale');
-  cfun.applyColorMap(preset);
-  cfun.setMappingRange(-360, 440);
-
-  actor.getProperty().setRGBTransferFunction(0, cfun);
-
-  const sampleDistance =
-    0.7 *
-    Math.sqrt(
-      imageData
-        .getSpacing()
-        .map(v => v * v)
-        .reduce((a, b) => a + b, 0)
-    );
-
-  mapper.setSampleDistance(sampleDistance);
-  return actor;
-}
+//const url = 'https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs';
+//const studyInstanceUID =
+// '1.3.6.1.4.1.14519.5.2.1.2744.7002.271803936741289691489150315969';
+//  '1.3.6.1.4.1.14519.5.2.1.2744.7002.373729467545468642229382466905';
+//const ctSeriesInstanceUID =
+// '1.3.6.1.4.1.14519.5.2.1.2744.7002.453958960749354309542907936863'
+//  '1.3.6.1.4.1.14519.5.2.1.2744.7002.182837959725425690842769990419';
+//const petSeriesInstanceUID =
+//  '1.3.6.1.4.1.14519.5.2.1.2744.7002.117357550898198415937979788256';
+//const searchInstanceOptions = {
+//  studyInstanceUID,
+//};
 
 class VTKMPRRotateExample extends Component {
   state = {
     volumes: [],
-    rotation: [],
   };
 
   async componentDidMount() {
@@ -178,42 +58,6 @@ class VTKMPRRotateExample extends Component {
     }
   }
 
-  async loadFromWadors() {
-    const imageIds = await createStudyImageIds(url, searchInstanceOptions);
-    let ctImageIds = imageIds.filter(imageId =>
-      imageId.includes(ctSeriesInstanceUID)
-    );
-
-    const ctImageDataPromise = loadDataset(ctImageIds, 'ctDisplaySet');
-    const promises = [ctImageDataPromise];
-
-    return new Promise((resolve, reject) => {
-      Promise.all(promises).then(([ctImageData, petImageData]) => {
-        const ctVol = createCT2dPipeline(ctImageData);
-
-        this.setState({
-          volumes: [ctVol],
-          rotation: [
-            {
-              x: 0,
-              y: 0,
-            },
-            {
-              x: 0,
-              y: 0,
-            },
-            {
-              x: 0,
-              y: 0,
-            },
-          ],
-        });
-
-        resolve();
-      });
-    });
-  }
-
   loadFromVti() {
     const reader = vtkHttpDataSetReader.newInstance({
       fetchGzip: true,
@@ -229,31 +73,15 @@ class VTKMPRRotateExample extends Component {
 
       this.setState({
         volumes: [volumeActor],
-        rotation: [
-          {
-            x: 0,
-            y: 0,
-          },
-          {
-            x: 0,
-            y: 0,
-          },
-          {
-            x: 0,
-            y: 0,
-          },
-        ],
       });
     });
   }
 
-  addWidget(index) {
-    this.apis.orientations = this.apis.orientations || [];
+  addCubeWidget(api) {
     // ----------------------------------------------------------------------------
     // Standard rendering code setup
     // ----------------------------------------------------------------------------
 
-    const api = this.apis[index];
     const renderer = api.genericRenderWindow.getRenderer();
     const renderWindow = api.genericRenderWindow.getRenderWindow();
 
@@ -277,7 +105,6 @@ class VTKMPRRotateExample extends Component {
       edgeColor: 'black',
       resolution: 400,
     });
-    // axes.setXPlusFaceProperty({ text: '+X' });
     axes.setXMinusFaceProperty({
       text: '-X',
       faceColor: '#ffff00',
@@ -321,122 +148,19 @@ class VTKMPRRotateExample extends Component {
 
     renderer.resetCamera();
     renderWindow.render();
-
-    this.apis.orientations[index] = orientationWidget;
   }
 
-  storeApi = viewportIndex => {
-    return api => {
-      this.apis[viewportIndex] = api;
+  storeApi = api => {
+    const istyle = vtkInteractorStyleMPRRotate.newInstance();
 
-      const renderWindow = api.genericRenderWindow.getRenderWindow();
-
-      // TODO: This is a hacky workaround because disabling the vtkInteractorStyleMPRSlice is currently
-      // broken. The camera.onModified is never removed.
-      renderWindow
-        .getInteractor()
-        .getInteractorStyle()
-        .setVolumeMapper(null);
-
-      const istyle = vtkInteractorStyleMPRRotate.newInstance();
-      //const istyle = vtkInteractorStyleMPRCrosshairs.newInstance();
-
-      renderWindow.getInteractor().setInteractorStyle(istyle);
-      istyle.setVolumeMapper(api.volumes[0]);
-
-      // api.volumes[0]
-      //   .getMapper()
-      //   .setBlendMode(BlendMode.MAXIMUM_INTENSITY_BLEND);
-      //api.volumes[0].getMapper().setBlendModeToMaximumIntensity();
-      //istyle.setSlabThickness(3);
-
-      const viewport = istyle.getViewport();
-
-      viewport.setOrientation(
-        volumeData[viewportIndex].slicePlaneNormal,
-        volumeData[viewportIndex].sliceViewUp
-      );
-
-      istyle.setViewport(viewport);
-
-      viewport
-        .getEventWindow()
-        .addEventListener(EVENTS.VIEWPORT_ROTATED, args => {
-          const rotation = this.state.rotation;
-
-          if (args.detail.dThetaX === 0 && args.detail.dThetaY === 0) {
-            return;
-          }
-
-          rotation[viewportIndex].x =
-            (rotation[viewportIndex].x + args.detail.dThetaY) % 360;
-          rotation[viewportIndex].y =
-            (rotation[viewportIndex].y + args.detail.dThetaX) % 360;
-
-          this.setState({ rotation });
-        });
-
-      this.addWidget(viewportIndex);
-
-      this.updateRotate(viewportIndex);
-    };
-  };
-
-  handleChangeX = (index, event) => {
-    const rotation = this.state.rotation;
-
-    rotation[index].x = +event.target.value;
-
-    this.setState({ rotation });
-
-    this.updateRotate(index);
-  };
-
-  handleChangeY = (index, event) => {
-    const rotation = this.state.rotation;
-
-    rotation[index].y = +event.target.value;
-
-    this.setState({ rotation });
-
-    this.updateRotate(index);
-  };
-
-  updateRotate = index => {
-    const api = this.apis[index];
-    const renderWindow = api.genericRenderWindow.getRenderWindow();
-    const rotation = this.state.rotation;
-    const istyle = renderWindow.getInteractor().getInteractorStyle();
-    const viewport = istyle.getViewport();
-    const dThetaY = rotation[index].x - volumeData[index].horizontalRotation;
-    const dThetaX = rotation[index].y - volumeData[index].verticalRotation;
-
-    viewport.rotate(-dThetaX, -dThetaY);
-
-    volumeData[index].horizontalRotation = rotation[index].x;
-    volumeData[index].verticalRotation = rotation[index].y;
-
-    this.apis.orientations[index].updateMarkerOrientation();
-
-    renderWindow.render();
+    this.apis = [api];
+    this.addCubeWidget(api);
+    api.setInteractorStyle({ istyle });
   };
 
   render() {
     if (!this.state.volumes || !this.state.volumes.length) {
       return <h4>Loading...</h4>;
-    }
-
-    const columns = [];
-
-    for (let index = 0; index < volumeData.length; index++) {
-      columns.push(
-        <div key={index.toString()} className="col-xs-12 col-sm-6">
-          <View2D
-            volumes={this.state.volumes}
-            onCreated={this.storeApi(index)}
-          />
-        </div>
-      );
     }
 
     return (
@@ -446,19 +170,17 @@ class VTKMPRRotateExample extends Component {
             <p>
               This example demonstrates how to use the MPR Rotate manipulator.
             </p>
-            {/* <div>
-              <label htmlFor="select_volume">Select Volume: </label>
-              <select
-                id="select_volume"
-                onChange={() => this.loadSelectedVolume()}
-              >
-                <option value="0">headsq.vti (small)</option>
-                <option value="1">Full Body (large)</option>
-              </select>
-            </div> */}
           </div>
         </div>
-        <div className="row">{columns}</div>
+        <div className="row">
+          <div className="col-xs-12 col-sm-6">
+            <View2D
+              volumes={this.state.volumes}
+              onCreated={this.storeApi}
+              orientation={{ sliceNormal: [1, 0, 0], viewUp: [0, 0, -1] }}
+            />
+          </div>
+        </div>
       </>
     );
   }

--- a/examples/VTKMPRRotateExample.js
+++ b/examples/VTKMPRRotateExample.js
@@ -27,6 +27,11 @@ window.cornerstoneWADOImageLoader = cornerstoneWADOImageLoader;
 //  studyInstanceUID,
 //};
 
+const voi = {
+  windowWidth: 1000,
+  windowCenter: 300 + 1024,
+};
+
 class VTKMPRRotateExample extends Component {
   state = {
     volumes: [],
@@ -156,6 +161,18 @@ class VTKMPRRotateExample extends Component {
     this.apis = [api];
     this.addCubeWidget(api);
     api.setInteractorStyle({ istyle });
+
+    const volume = api.volumes[0];
+    const rgbTransferFunction = volume.getProperty().getRGBTransferFunction(0);
+
+    const low = voi.windowCenter - voi.windowWidth / 2;
+    const high = voi.windowCenter + voi.windowWidth / 2;
+
+    rgbTransferFunction.setMappingRange(low, high);
+
+    const renderWindow = api.genericRenderWindow.getRenderWindow();
+
+    renderWindow.render();
   };
 
   render() {

--- a/src/VTKViewport/View2D.js
+++ b/src/VTKViewport/View2D.js
@@ -6,6 +6,7 @@ import vtkWidgetManager from 'vtk.js/Sources/Widgets/Core/WidgetManager';
 import vtkInteractorStyleMPRSlice from './vtkInteractorStyleMPRSlice';
 import vtkPaintFilter from 'vtk.js/Sources/Filters/General/PaintFilter';
 import vtkPaintWidget from 'vtk.js/Sources/Widgets/Widgets3D/PaintWidget';
+import vtkSVGWidgetManager from './vtkSVGWidgetManager';
 
 import ViewportOverlay from '../ViewportOverlay/ViewportOverlay.js';
 import { ViewTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
@@ -47,6 +48,7 @@ export default class View2D extends Component {
       paintStart: createSub(),
       paintEnd: createSub(),
     };
+    this.interactorStyleSubs = [];
     this.state = {
       voi: this.getVOI(props.volumes[0]),
     };
@@ -193,11 +195,24 @@ export default class View2D extends Component {
     });
     this.updatePaintbrush();
 
+    const svgWidgetManager = vtkSVGWidgetManager.newInstance();
+
+    svgWidgetManager.setRenderer(this.renderer);
+    svgWidgetManager.setScale(1);
+
+    this.svgWidgetManager = svgWidgetManager;
+
     // TODO: Not sure why this is necessary to force the initial draw
     this.genericRenderWindow.resize();
 
     const boundUpdateVOI = this.updateVOI.bind(this);
     const boundGetOrienation = this.getOrientation.bind(this);
+    const boundSetInteractorStyle = this.setInteractorStyle.bind(this);
+    const boundGetSlabThickness = this.getSlabThickness.bind(this);
+    const boundSetSlabThickness = this.setSlabThickness.bind(this);
+    const boundAddSVGWidget = this.addSVGWidget.bind(this);
+
+    this.svgWidgets = {};
 
     if (this.props.onCreated) {
       /**
@@ -208,18 +223,118 @@ export default class View2D extends Component {
       const api = {
         genericRenderWindow: this.genericRenderWindow,
         widgetManager: this.widgetManager,
+        svgWidgetManager: this.svgWidgetManager,
+        addSVGWidget: boundAddSVGWidget,
         container: this.container.current,
         widgets,
+        svgWidgets: this.svgWidgets,
         filters,
         actors,
         volumes,
         _component: this,
         updateVOI: boundUpdateVOI,
         getOrientation: boundGetOrienation,
+        setInteractorStyle: boundSetInteractorStyle,
+        getSlabThickness: boundGetSlabThickness,
+        setSlabThickness: boundSetSlabThickness,
       };
 
       this.props.onCreated(api);
     }
+  }
+
+  addSVGWidget(widget, name) {
+    const { svgWidgetManager } = this;
+
+    svgWidgetManager.addWidget(widget);
+    svgWidgetManager.render();
+
+    this.svgWidgets[name] = widget;
+  }
+
+  getSlabThickness() {
+    const renderWindow = this.genericRenderWindow.getRenderWindow();
+    const currentIStyle = renderWindow.getInteractor().getInteractorStyle();
+
+    if (currentIStyle.getSlabThickness) {
+      return currentIStyle.getSlabThickness();
+    }
+
+    //return this.currentSlabThickness;
+  }
+
+  setSlabThickness(slabThickness) {
+    const renderWindow = this.genericRenderWindow.getRenderWindow();
+    const istyle = renderWindow.getInteractor().getInteractorStyle();
+
+    if (istyle.setSlabThickness) {
+      istyle.setSlabThickness(slabThickness);
+    }
+
+    renderWindow.render();
+  }
+
+  setInteractorStyle({ istyle, callbacks = {}, configuration = {} }) {
+    const { volumes } = this.props;
+    const renderWindow = this.genericRenderWindow.getRenderWindow();
+    const currentIStyle = renderWindow.getInteractor().getInteractorStyle();
+
+    // unsubscribe from previous iStyle's callbacks.
+    while (this.interactorStyleSubs.length) {
+      this.interactorStyleSubs.pop().unsubscribe();
+    }
+
+    let currentViewport;
+    if (currentIStyle.getViewport && istyle.getViewport) {
+      currentViewport = currentIStyle.getViewport();
+    }
+
+    const slabThickness = this.getSlabThickness();
+
+    /*
+    let currentSlabThickness;
+    if (currentIStyle.getSlabThickness && istyle.getSlabThickness) {
+      currentSlabThickness = currentIStyle.getSlabThickness();
+      this.currentSlabThickness = currentSlabThickness;
+    }
+    */
+
+    const interactor = renderWindow.getInteractor();
+
+    interactor.setInteractorStyle(istyle);
+
+    // TODO: Not sure why this is required the second time this function is called
+    istyle.setInteractor(interactor);
+
+    if (currentViewport) {
+      istyle.setViewport(currentViewport);
+    }
+
+    if (istyle.getVolumeMapper() !== volumes[0]) {
+      if (slabThickness && istyle.setSlabThickness) {
+        istyle.setSlabThickness(slabThickness);
+      }
+
+      istyle.setVolumeMapper(volumes[0]);
+    }
+
+    // Add appropriate callbacks
+    Object.keys(callbacks).forEach(key => {
+      if (typeof istyle[key] === 'function') {
+        const subscription = istyle[key](callbacks[key]);
+
+        if (subscription && typeof subscription.unsubscribe === 'function') {
+          this.interactorStyleSubs.push(subscription);
+        }
+      }
+    });
+
+    // Set Configuration
+    if (configuration) {
+      istyle.set(configuration);
+    }
+
+    renderWindow.render();
   }
 
   updateVOI(windowWidth, windowCenter) {


### PR DESCRIPTION
Make the platform more Developer friendly and extensible:


- Makes swapping/instatiation of tools cleaner.
- Manager istyle callbacks within the component, allow synchronisation by passing in callbacks when setting a tool through the API.
- Updated all examples.
- Moved as much logic from OHIF/Viewers down to the component as possible.

The paint widget in `View2D`, and the `View3D` component are currently untouched.