### PR TITLE
Fix cross product to compute Z direction in getImageData

### DIFF
--- a/src/lib/getImageData.js
+++ b/src/lib/getImageData.js
@@ -23,7 +23,14 @@ export default function getImageData(imageIds, displaySetInstanceUid) {
     columnCosines[1],
     columnCosines[2]
   );
-  const crossProduct = colCosineVec.cross(rowCosineVec);
+
+  const crossProduct = new Vector3(
+    rowCosines[0],
+    rowCosines[1],
+    rowCosines[2]
+  );
+
+  crossProduct.cross(colCosineVec);
 
   const orientation = determineOrientation(crossProduct);
   const zAxis = computeZAxis(orientation, metaDataMap);

--- a/src/lib/getImageData.js
+++ b/src/lib/getImageData.js
@@ -28,9 +28,7 @@ export default function getImageData(imageIds, displaySetInstanceUid) {
     rowCosines[0],
     rowCosines[1],
     rowCosines[2]
-  );
-
-  crossProduct.cross(colCosineVec);
+  ).cross(colCosineVec);
 
   const orientation = determineOrientation(crossProduct);
   const zAxis = computeZAxis(orientation, metaDataMap);


### PR DESCRIPTION
The cross method from cornerstone-math modifies the calling object. Update code to correctly use this function.