### PR TITLE
chore: support monorepo PWA linking w/ yarn link

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "repository": "OHIF/react-vtkjs-viewport",
   "main": "dist/index.umd.js",
+  "module": "src/index.js",
   "engines": {
     "node": ">=8",
     "npm": ">=5"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,13 @@
+module.exports = function(ctx) {
+  ctx = ctx || {};
+  ctx.env = ctx.env || 'development';
+
+  return {
+    map: ctx.env === 'development' ? ctx.map : false,
+    plugins: {
+      'postcss-import': {},
+      'postcss-preset-env': {},
+      cssnano: ctx.env === 'production' ? {} : false,
+    },
+  };
+};


### PR DESCRIPTION
Development changes:

- Run `yarn link` in `react-vtkjs-viewport` project root
- Run `yarn link react-vtkjs-viewport` in monorepo root

WebPack will now watch `react-vtkjs-viewport` for changes and rebuild/reload when detected.

The "module" key tells WebPack to use `react-vtkjs-viewport`'s `src/index.js` as the entry point (if it is available). Because our PWA build is compatible with `react-vtkjs-viewport`, everything works seamlessly :+1:

For individuals importing `react-vtkjs-viewport` without a link, they will continue to use the "main" key's entrypoint (`dist/index.umd.js`), as we don't publish the source when shipping to NPM (this is good, as we don't have an ESM target for `module`)