### PR TITLE
feat: dispatch vtk scroll event

### DIFF
--- a/src/VTKViewport/View2D.js
+++ b/src/VTKViewport/View2D.js
@@ -105,7 +105,7 @@ export default class View2D extends Component {
     // the vtkOpenGLRenderer instance.
     oglrw.buildPass(true);
 
-    const istyle = vtkInteractorStyleMPRSlice.newInstance({ uid });
+    const istyle = vtkInteractorStyleMPRSlice.newInstance();
     this.renderWindow.getInteractor().setInteractorStyle(istyle);
 
     const inter = this.renderWindow.getInteractor();
@@ -253,19 +253,6 @@ export default class View2D extends Component {
 
       this.props.onCreated(api);
     }
-
-    // Set tracking id on interactorStyle model
-    // If we set it immediately, this value is blown out by model's default
-    setTimeout(() => {
-      this.setUid(uid);
-    }, 1000);
-  }
-
-  setUid(uid) {
-    const renderWindow = this.genericRenderWindow.getRenderWindow();
-    const istyle = renderWindow.getInteractor().getInteractorStyle();
-
-    istyle.setUid(uid);
   }
 
   addSVGWidget(widget, name) {

--- a/src/VTKViewport/vtkInteractorStyleMPRSlice.js
+++ b/src/VTKViewport/vtkInteractorStyleMPRSlice.js
@@ -203,6 +203,7 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
   let cameraSub = null;
   let interactorSub = null;
   const superSetInteractor = publicAPI.setInteractor;
+
   publicAPI.setInteractor = interactor => {
     superSetInteractor(interactor);
 
@@ -286,10 +287,18 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
   // Only run the onScroll callback if called from scrolling,
   // preventing manual setSlice calls from triggering the CB.
   publicAPI.scrollToSlice = slice => {
+    // Dispatch custom event
+    const vtkScrollEvent = new CustomEvent('vtkscrollevent', {
+      detail: { uid: publicAPI.getUid() },
+    });
+    window.dispatchEvent(vtkScrollEvent);
+
     const slicePoint = publicAPI.setSlice(slice);
     // run Callback
     const onScroll = publicAPI.getOnScroll();
-    if (onScroll) onScroll(slicePoint);
+    if (onScroll) {
+      onScroll(slicePoint);
+    }
   };
 
   publicAPI.setSlice = slice => {
@@ -453,6 +462,14 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
     camera.setThicknessFromFocalPoint(slabThickness);
   };
 
+  publicAPI.setUid = uid => {
+    model.uid = uid;
+  };
+
+  publicAPI.getUid = () => {
+    return model.uid;
+  };
+
   setManipulators();
 }
 
@@ -462,6 +479,7 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
 
 const DEFAULT_VALUES = {
   slabThickness: 0.1,
+  uid: '',
 };
 
 // ----------------------------------------------------------------------------
@@ -481,6 +499,7 @@ export function extend(publicAPI, model, initialValues = {}) {
 
 // ----------------------------------------------------------------------------
 
+// Returns new instance factory, takes initial values object
 export const newInstance = macro.newInstance(
   extend,
   'vtkInteractorStyleMPRSlice'

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -3,6 +3,7 @@ import formatDA from './formatDA';
 import formatTM from './formatTM';
 import formatNumberPrecision from './formatNumberPrecision';
 import isValidNumber from './isValidNumber';
+import uuidv4 from './uuidv4.js';
 
 const helpers = {
   formatPN,
@@ -12,4 +13,4 @@ const helpers = {
   isValidNumber,
 };
 
-export { helpers };
+export { helpers, uuidv4 };

--- a/src/helpers/uuidv4.js
+++ b/src/helpers/uuidv4.js
@@ -1,0 +1,8 @@
+// From: https://stackoverflow.com/a/2117523/1867984
+
+// prettier-ignore
+export default function uuidv4() {
+  return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+  );
+}


### PR DESCRIPTION
Per our conversation yesterday, I need a way to know when and which a VTK Viewport is scrolled. It appears the default event is blocked/prevented by VTK internally. This attempts to re-emit the event as a `vtkscrollevent` so I can consume it somewhere else.

The addition of a `uid` on the "api" object, and on the `interactorStyle` are to provide a way for me to determine, for a given `viewportIndex`, if it was the event's emitter.

Related: https://github.com/OHIF/Viewers/pull/1139