### PR TITLE
Fix Crosshair Update on scroll/pan/zoom.

### DIFF
--- a/examples/VTKCrosshairsExample.js
+++ b/examples/VTKCrosshairsExample.js
@@ -63,6 +63,7 @@ function createStudyImageIds(baseUrl, studySearchOptions) {
 class VTKCrosshairsExample extends Component {
   state = {
     volumes: [],
+    displayCrosshairs: true,
   };
 
   async componentDidMount() {
@@ -145,6 +146,22 @@ class VTKCrosshairsExample extends Component {
     });
   }
 
+  toggleCrosshairs = () => {
+    const { displayCrosshairs } = this.state;
+    const apis = this.apis;
+
+    const shouldDisplayCrosshairs = !displayCrosshairs;
+
+    apis.forEach(api => {
+      const { svgWidgetManager, svgWidgets } = api;
+      svgWidgets.crosshairsWidget.setDisplay(shouldDisplayCrosshairs);
+
+      svgWidgetManager.render();
+    });
+
+    this.setState({ displayCrosshairs: shouldDisplayCrosshairs });
+  };
+
   render() {
     if (!this.state.volumes || !this.state.volumes.length) {
       return <h4>Loading...</h4>;
@@ -166,6 +183,14 @@ class VTKCrosshairsExample extends Component {
               max="5000"
               onChange={this.handleSlabThicknessChange.bind(this)}
             />
+          </div>
+          <div className="col-xs-4">
+            <p>Click bellow to toggle crosshairs on/off.</p>
+            <button onClick={this.toggleCrosshairs}>
+              {this.state.displayCrosshairs
+                ? 'Hide Crosshairs'
+                : 'Show Crosshairs'}
+            </button>
           </div>
         </div>
         <div className="row">

--- a/examples/VTKCrosshairsExample.js
+++ b/examples/VTKCrosshairsExample.js
@@ -130,6 +130,15 @@ class VTKCrosshairsExample extends Component {
       api.setSlabThickness(0.1);
 
       renderWindow.render();
+
+      // Its up to the layout manager of an app to know how many viewports are being created.
+      if (apis[0] && apis[1] && apis[2]) {
+        //const api = apis[0];
+
+        const api = apis[0];
+
+        api.svgWidgets.crosshairsWidget.resetCrosshairs(apis, 0);
+      }
     };
   };
 

--- a/src/VTKViewport/View2D.js
+++ b/src/VTKViewport/View2D.js
@@ -59,6 +59,8 @@ export default class View2D extends Component {
     this.state = {
       voi: this.getVOI(props.volumes[0]),
     };
+
+    this.apiProperties = {};
   }
 
   updatePaintbrush() {
@@ -218,6 +220,8 @@ export default class View2D extends Component {
     const boundGetSlabThickness = this.getSlabThickness.bind(this);
     const boundSetSlabThickness = this.setSlabThickness.bind(this);
     const boundAddSVGWidget = this.addSVGWidget.bind(this);
+    const boundGetApiProperty = this.getApiProperty.bind(this);
+    const boundSetApiProperty = this.setApiProperty.bind(this);
 
     this.svgWidgets = {};
 
@@ -244,10 +248,21 @@ export default class View2D extends Component {
         setInteractorStyle: boundSetInteractorStyle,
         getSlabThickness: boundGetSlabThickness,
         setSlabThickness: boundSetSlabThickness,
+        get: boundGetApiProperty,
+        set: boundSetApiProperty,
+        type: 'VIEW2D',
       };
 
       this.props.onCreated(api);
     }
+  }
+
+  getApiProperty(propertyName) {
+    return this.apiProperties[propertyName];
+  }
+
+  setApiProperty(propertyName, value) {
+    this.apiProperties[propertyName] = value;
   }
 
   addSVGWidget(widget, name) {

--- a/src/VTKViewport/View2D.js
+++ b/src/VTKViewport/View2D.js
@@ -327,15 +327,6 @@ export default class View2D extends Component {
     }
 
     const slabThickness = this.getSlabThickness();
-
-    /*
-    let currentSlabThickness;
-    if (currentIStyle.getSlabThickness && istyle.getSlabThickness) {
-      currentSlabThickness = currentIStyle.getSlabThickness();
-      this.currentSlabThickness = currentSlabThickness;
-    }
-    */
-
     const interactor = renderWindow.getInteractor();
 
     interactor.setInteractorStyle(istyle);

--- a/src/VTKViewport/View3D.js
+++ b/src/VTKViewport/View3D.js
@@ -121,7 +121,8 @@ export default class View3D extends Component {
         filters,
         actors,
         volumes,
-        _component: this,
+        type: 'VIEW3D',
+        _component: this, // Backdoor still open for now whilst the API isn't as mature as View2D.
       };
 
       this.props.onCreated(api);

--- a/src/VTKViewport/vtkInteractorStyleMPRCrosshairs.js
+++ b/src/VTKViewport/vtkInteractorStyleMPRCrosshairs.js
@@ -2,7 +2,6 @@ import macro from 'vtk.js/Sources/macro';
 import vtkInteractorStyleMPRSlice from './vtkInteractorStyleMPRSlice.js';
 import Constants from 'vtk.js/Sources/Rendering/Core/InteractorStyle/Constants';
 import vtkCoordinate from 'vtk.js/Sources/Rendering/Core/Coordinate';
-import { updateCrosshairs } from './vtkSVGCrosshairsWidget';
 
 const { States } = Constants;
 
@@ -20,6 +19,7 @@ function vtkInteractorStyleMPRCrosshairs(publicAPI, model) {
 
   function moveCrosshairs(callData) {
     const { apis, apiIndex } = model;
+    const api = apis[apiIndex];
 
     const pos = callData.position;
     const renderer = callData.pokedRenderer;
@@ -33,7 +33,6 @@ function vtkInteractorStyleMPRCrosshairs(publicAPI, model) {
     const camera = renderer.getActiveCamera();
     const directionOfProjection = camera.getDirectionOfProjection();
 
-    const api = apis[apiIndex];
     const halfSlabThickness = api.getSlabThickness() / 2;
 
     // Add half of the slab thickness to the world position, such that we select
@@ -43,7 +42,7 @@ function vtkInteractorStyleMPRCrosshairs(publicAPI, model) {
       worldPos[i] += halfSlabThickness * directionOfProjection[i];
     }
 
-    updateCrosshairs(worldPos, apis, apiIndex);
+    api.svgWidgets.crosshairsWidget.moveCrosshairs(worldPos, apis, apiIndex);
 
     publicAPI.invokeInteractionEvent({ type: 'InteractionEvent' });
   }
@@ -82,6 +81,23 @@ function vtkInteractorStyleMPRCrosshairs(publicAPI, model) {
         publicAPI.superHandleLeftButtonRelease();
         break;
     }
+  };
+
+  publicAPI.setApis = apis => {
+    model.apis = apis;
+    // TODO -> If we bundle api and APIIndex into one setter it'll be a lot cleaner.
+  };
+
+  publicAPI.getApis = () => {
+    return model.apis;
+  };
+
+  publicAPI.setApiIndex = apiIndex => {
+    model.apiIndex = apiIndex;
+  };
+
+  publicAPI.getApiIndex = () => {
+    return model.apiIndex;
   };
 }
 

--- a/src/VTKViewport/vtkInteractorStyleMPRCrosshairs.js
+++ b/src/VTKViewport/vtkInteractorStyleMPRCrosshairs.js
@@ -82,23 +82,6 @@ function vtkInteractorStyleMPRCrosshairs(publicAPI, model) {
         break;
     }
   };
-
-  publicAPI.setApis = apis => {
-    model.apis = apis;
-    // TODO -> If we bundle api and APIIndex into one setter it'll be a lot cleaner.
-  };
-
-  publicAPI.getApis = () => {
-    return model.apis;
-  };
-
-  publicAPI.setApiIndex = apiIndex => {
-    model.apiIndex = apiIndex;
-  };
-
-  publicAPI.getApiIndex = () => {
-    return model.apiIndex;
-  };
 }
 
 // ----------------------------------------------------------------------------

--- a/src/VTKViewport/vtkInteractorStyleMPRCrosshairs.js
+++ b/src/VTKViewport/vtkInteractorStyleMPRCrosshairs.js
@@ -38,6 +38,7 @@ function vtkInteractorStyleMPRCrosshairs(publicAPI, model) {
 
     // Add half of the slab thickness to the world position, such that we select
     // The center of the slice.
+
     for (let i = 0; i < worldPos.length; i++) {
       worldPos[i] += halfSlabThickness * directionOfProjection[i];
     }

--- a/src/VTKViewport/vtkInteractorStyleMPRCrosshairs.js
+++ b/src/VTKViewport/vtkInteractorStyleMPRCrosshairs.js
@@ -1,8 +1,8 @@
 import macro from 'vtk.js/Sources/macro';
-import vtkMatrixBuilder from 'vtk.js/Sources/Common/Core/MatrixBuilder';
 import vtkInteractorStyleMPRSlice from './vtkInteractorStyleMPRSlice.js';
 import Constants from 'vtk.js/Sources/Rendering/Core/InteractorStyle/Constants';
 import vtkCoordinate from 'vtk.js/Sources/Rendering/Core/Coordinate';
+import { updateCrosshairs } from './vtkSVGCrosshairsWidget';
 
 const { States } = Constants;
 
@@ -20,13 +20,14 @@ function vtkInteractorStyleMPRCrosshairs(publicAPI, model) {
 
   function moveCrosshairs(callData) {
     const { apis, apiIndex } = model;
-    const pos = [callData.position.x, callData.position.y];
+
+    const pos = callData.position;
     const renderer = callData.pokedRenderer;
 
     const dPos = vtkCoordinate.newInstance();
     dPos.setCoordinateSystemToDisplay();
 
-    dPos.setValue(pos[0], pos[1], 0);
+    dPos.setValue(pos.x, pos.y, 0);
     let worldPos = dPos.getComputedWorldValue(renderer);
 
     const camera = renderer.getActiveCamera();
@@ -35,57 +36,13 @@ function vtkInteractorStyleMPRCrosshairs(publicAPI, model) {
     const api = apis[apiIndex];
     const halfSlabThickness = api.getSlabThickness() / 2;
 
+    // Add half of the slab thickness to the world position, such that we select
+    // The center of the slice.
     for (let i = 0; i < worldPos.length; i++) {
       worldPos[i] += halfSlabThickness * directionOfProjection[i];
     }
 
-    // Add half of the slab thickness to the world position, such that we select
-    // The center of the slice.
-
-    if (apis === undefined || apiIndex === undefined) {
-      console.error(
-        'apis and apiIndex must be set on the vtkInteractorStyleMPRCrosshairs.'
-      );
-    }
-
-    // Set camera focal point to world coordinate for linked views
-    apis.forEach((api, viewportIndex) => {
-      if (viewportIndex !== apiIndex) {
-        // We are basically doing the same as getSlice but with the world coordinate
-        // that we want to jump to instead of the camera focal point.
-        // I would rather do the camera adjustment directly but I keep
-        // doing it wrong and so this is good enough for now.
-        const renderWindow = api.genericRenderWindow.getRenderWindow();
-
-        const istyle = renderWindow.getInteractor().getInteractorStyle();
-        const sliceNormal = istyle.getSliceNormal();
-        const transform = vtkMatrixBuilder
-          .buildFromDegree()
-          .identity()
-          .rotateFromDirections(sliceNormal, [1, 0, 0]);
-
-        const mutatedWorldPos = worldPos.slice();
-        transform.apply(mutatedWorldPos);
-        const slice = mutatedWorldPos[0];
-
-        istyle.setSlice(slice);
-
-        renderWindow.render();
-      }
-
-      const renderer = api.genericRenderWindow.getRenderer();
-      const wPos = vtkCoordinate.newInstance();
-      wPos.setCoordinateSystemToWorld();
-      wPos.setValue(worldPos);
-
-      const displayPosition = wPos.getComputedDisplayValue(renderer);
-      const { svgWidgetManager } = api;
-      api.svgWidgets.crosshairsWidget.setPoint(
-        displayPosition[0],
-        displayPosition[1]
-      );
-      svgWidgetManager.render();
-    });
+    updateCrosshairs(worldPos, apis, apiIndex);
 
     publicAPI.invokeInteractionEvent({ type: 'InteractionEvent' });
   }
@@ -125,13 +82,6 @@ function vtkInteractorStyleMPRCrosshairs(publicAPI, model) {
         break;
     }
   };
-
-  publicAPI.setApis = apis => {
-    model.apis = apis;
-  };
-  publicAPI.setApiIndex = apiIndex => {
-    model.apiIndex = apiIndex;
-  };
 }
 
 // ----------------------------------------------------------------------------
@@ -148,7 +98,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   // Inheritance
   vtkInteractorStyleMPRSlice.extend(publicAPI, model, initialValues);
 
-  macro.setGet(publicAPI, model, ['callback']);
+  macro.setGet(publicAPI, model, ['callback', 'apis', 'apiIndex', 'onScroll']);
 
   // Object specific methods
   vtkInteractorStyleMPRCrosshairs(publicAPI, model);

--- a/src/VTKViewport/vtkInteractorStyleMPRSlice.js
+++ b/src/VTKViewport/vtkInteractorStyleMPRSlice.js
@@ -67,11 +67,6 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
     dragEnabled: false,
   });
 
-  // model.scrollManipulator = vtkMouseRangeRotateManipulator.newInstance({
-  //   scrollEnabled: true,
-  //   dragEnabled: false,
-  // });
-
   // cache for sliceRange
   const cache = {
     sliceNormal: [0, 0, 0],
@@ -307,29 +302,30 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
         'cachedCrosshairWorldPosition'
       );
 
-      const temp = api.svgWidgets.crosshairsWidget.getPoint();
-
-      let displayPosition;
+      let doubleDisplayPosition;
 
       if (cachedCrosshairWorldPosition) {
         const wPos = vtkCoordinate.newInstance();
         wPos.setCoordinateSystemToWorld();
         wPos.setValue(cachedCrosshairWorldPosition);
 
-        displayPosition = wPos.getComputedDisplayValue(renderer);
+        doubleDisplayPosition = wPos.getComputedDoubleDisplayValue(renderer);
       } else {
         // If scrolling before crosshairs have been used, instantiate them.
         const wPos = vtkCoordinate.newInstance();
         wPos.setCoordinateSystemToWorld();
         wPos.setValue(slicePoint);
 
-        displayPosition = wPos.getComputedDisplayValue(renderer);
+        doubleDisplayPosition = wPos.getComputedDoubleDisplayValue(renderer);
       }
+
+      console.log('//// recalculated displayPosition');
+      console.log(doubleDisplayPosition);
 
       const dPos = vtkCoordinate.newInstance();
       dPos.setCoordinateSystemToDisplay();
 
-      dPos.setValue(displayPosition[0], displayPosition[1], 0);
+      dPos.setValue(doubleDisplayPosition[0], doubleDisplayPosition[1], 0);
       let worldPos = dPos.getComputedWorldValue(renderer);
 
       const camera = renderer.getActiveCamera();
@@ -337,10 +333,14 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
       const halfSlabThickness = api.getSlabThickness() / 2;
 
       // Add half of the slab thickness to the world position, such that we select
-      // The center of the slice.
-      // for (let i = 0; i < worldPos.length; i++) {
-      //   worldPos[i] += halfSlabThickness * directionOfProjection[i];
-      // }
+      //The center of the slice.
+
+      for (let i = 0; i < worldPos.length; i++) {
+        worldPos[i] += halfSlabThickness * directionOfProjection[i];
+      }
+
+      console.log('//// recalculated worldPos');
+      console.log(worldPos);
 
       // if (cachedCrosshairWorldPosition) {
       //   worldPos = cachedCrosshairWorldPosition;
@@ -364,12 +364,14 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
     }
 
     // run Callback
+    /*
     const onScroll = publicAPI.getOnScroll();
     if (onScroll) {
       onScroll({
         slicePoint,
       });
     }
+    */
   };
 
   publicAPI.setSlice = slice => {


### PR DESCRIPTION
This PR makes scroll/pan/zoom update the crosshairs correctly when using either `vtkInteractorStyleMPRSlice` or `vtkInteractorStyleMPRCrosshairs`.

Updates for `vtkInteractorStyleMPRRotate` will come in the future or during a large refactor of the iStyle framework we have in place.