### PR TITLE
fix: 🐛 Fix onScroll throwing when crosshairs arent initialised

### DIFF
--- a/src/VTKViewport/vtkInteractorStyleMPRSlice.js
+++ b/src/VTKViewport/vtkInteractorStyleMPRSlice.js
@@ -377,6 +377,11 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
         'cachedCrosshairWorldPosition'
       );
 
+      if (cachedCrosshairWorldPosition === undefined) {
+        // Crosshairs not initilised.
+        return;
+      }
+
       const wPos = vtkCoordinate.newInstance();
       wPos.setCoordinateSystemToWorld();
       wPos.setValue(cachedCrosshairWorldPosition);


### PR DESCRIPTION
Prevents the onScroll callback from trying to reset crosshairs when they haven't been initialised yet.