### PR TITLE
fix: 🐛 Memory leak in View2D

### DIFF
--- a/src/VTKViewport/View2D.js
+++ b/src/VTKViewport/View2D.js
@@ -619,6 +619,8 @@ export default class View2D extends Component {
     if (this.props.onDestroyed) {
       this.props.onDestroyed();
     }
+
+    this.genericRenderWindow.delete();
   }
 
   getVOI = actor => {


### PR DESCRIPTION
We need to tell vtkjs to release the memory when our component is no longer in use.

Otherwise renderer context will stay and after a while it will crash the browser.