### PR TITLE
fix: 🐛 Memory leak in View3D

### DIFF
--- a/src/VTKViewport/View3D.js
+++ b/src/VTKViewport/View3D.js
@@ -284,6 +284,8 @@ export default class View3D extends Component {
     if (this.props.onDestroyed) {
       this.props.onDestroyed();
     }
+
+    this.genericRenderWindow.delete();
   }
 
   render() {


### PR DESCRIPTION
We need to tell vtkjs to release the memory when our component is no longer in use.

Otherwise renderer context will stay and after a while it will crash the browser.