### PR TITLE
[OHIF/Viewers: IDC-1957] Switch to using request pool manager.

### DIFF
--- a/examples/VTKCornerstonePaintingSyncExample.js
+++ b/examples/VTKCornerstonePaintingSyncExample.js
@@ -145,7 +145,8 @@ class VTKCornerstonePaintingSyncExample extends Component {
       };
 
       loadImageData(imageDataObject);
-      Promise.all(imageDataObject.insertPixelDataPromises).then(() => {
+
+      const onAllPixelDataInsertedCallback = () => {
         const { actor } = createActorMapper(imageDataObject.vtkImageData);
 
         const rgbTransferFunction = actor
@@ -166,7 +167,9 @@ class VTKCornerstonePaintingSyncExample extends Component {
           globalOpacity: segmentationModule.configuration.fillAlpha,
           outlineThickness: segmentationModule.configuration.outlineThickness,
         });
-      });
+      };
+
+      imageDataObject.onAllPixelDataInserted(onAllPixelDataInsertedCallback);
     });
   }
 
@@ -321,6 +324,7 @@ class VTKCornerstonePaintingSyncExample extends Component {
                   colorLUT,
                   globalOpacity,
                   outlineThickness,
+                  segmentsDefaultProperties: [],
                   visible: true,
                   renderOutline: true,
                 }}

--- a/examples/VTKCrosshairsExample.js
+++ b/examples/VTKCrosshairsExample.js
@@ -77,7 +77,7 @@ class VTKCrosshairsExample extends Component {
 
     const ctImageDataObject = loadDataset(ctImageIds, 'ctDisplaySet');
 
-    Promise.all(ctImageDataObject.insertPixelDataPromises).then(() => {
+    const onAllPixelDataInsertedCallback = () => {
       const ctImageData = ctImageDataObject.vtkImageData;
 
       const range = ctImageData
@@ -97,7 +97,9 @@ class VTKCrosshairsExample extends Component {
       this.setState({
         volumes: [ctVol],
       });
-    });
+    };
+
+    ctImageDataObject.onAllPixelDataInserted(onAllPixelDataInsertedCallback);
   }
 
   storeApi = viewportIndex => {

--- a/examples/VTKFusionExample.js
+++ b/examples/VTKFusionExample.js
@@ -332,34 +332,32 @@ class VTKFusionExample extends Component {
 
     loadImageData(imageDataObject);
 
-    const { insertPixelDataPromises } = imageDataObject;
+    const numberOfFrames = imageIds.length;
 
-    const numberOfFrames = insertPixelDataPromises.length;
+    const onPixelDataInsertedCallback = numberProcessed => {
+      const percentComplete = Math.floor(
+        (numberProcessed * 100) / numberOfFrames
+      );
 
-    // TODO -> Maybe the component itself should do this.
-    insertPixelDataPromises.forEach(promise => {
-      promise.then(numberProcessed => {
-        const percentComplete = Math.floor(
-          (numberProcessed * 100) / numberOfFrames
-        );
+      if (this.state.percentComplete !== percentComplete) {
+        const stateUpdate = {};
 
-        if (this.state.percentComplete !== percentComplete) {
-          const stateUpdate = {};
+        stateUpdate[percentageCompleteStateName] = percentComplete;
 
-          stateUpdate[percentageCompleteStateName] = percentComplete;
+        this.setState(stateUpdate);
+      }
 
-          this.setState(stateUpdate);
-        }
+      if (percentComplete % 20 === 0) {
+        this.rerenderAll();
+      }
+    };
 
-        if (percentComplete % 20 === 0) {
-          this.rerenderAll();
-        }
-      });
-    });
-
-    Promise.all(insertPixelDataPromises).then(() => {
+    const onAllPixelDataInsertedCallback = () => {
       this.rerenderAll();
-    });
+    };
+
+    imageDataObject.onPixelDataInserted(onPixelDataInsertedCallback);
+    imageDataObject.onAllPixelDataInserted(onAllPixelDataInsertedCallback);
 
     return imageDataObject;
   }

--- a/examples/VTKLoadImageDataExample.js
+++ b/examples/VTKLoadImageDataExample.js
@@ -109,16 +109,15 @@ class VTKLoadImageDataExample extends Component {
 
         loadImageData(imageDataObject);
 
-        const { insertPixelDataPromises } = imageDataObject;
-        insertPixelDataPromises.forEach(promise => {
-          promise.then(numberProcessed => {
-            const percentComplete = Math.floor(
-              (numberProcessed * 100) / insertPixelDataPromises.length
-            );
+        const onPixelDataInsertedCallback = numberProcessed => {
+          const percentComplete = Math.floor(
+            (numberProcessed * 100) / imageIds.length
+          );
 
-            console.log(`Processing: ${percentComplete}%`);
-          });
-        });
+          console.log(`Processing: ${percentComplete}%`);
+        };
+
+        imageDataObject.onPixelDataInserted(onPixelDataInsertedCallback);
 
         const { actor } = createActorMapper(imageDataObject.vtkImageData);
 
@@ -154,9 +153,11 @@ class VTKLoadImageDataExample extends Component {
 
       istyle.setSliceOrientation(slicePlaneNormal, sliceViewUp);
 
-      this.imageDataObject.insertPixelDataPromises.forEach(promise => {
-        promise.then(() => renderWindow.render());
-      });
+      const onPixelDataInsertedCallback = () => {
+        renderWindow.render();
+      };
+
+      this.imageDataObject.onPixelDataInserted(onPixelDataInsertedCallback);
 
       renderWindow.render();
     };

--- a/examples/VTKVolumeRenderingExample.js
+++ b/examples/VTKVolumeRenderingExample.js
@@ -299,30 +299,28 @@ class VTKFusionExample extends Component {
 
     loadImageData(imageDataObject);
 
-    const { insertPixelDataPromises } = imageDataObject;
+    const numberOfFrames = imageIds.length;
 
-    const numberOfFrames = insertPixelDataPromises.length;
+    const onPixelDataInsertedCallback = numberProcessed => {
+      const percentComplete = Math.floor(
+        (numberProcessed * 100) / numberOfFrames
+      );
 
-    // TODO -> Maybe the component itself should do this.
-    insertPixelDataPromises.forEach(promise => {
-      promise.then(numberProcessed => {
-        const percentComplete = Math.floor(
-          (numberProcessed * 100) / numberOfFrames
-        );
+      if (this.state.percentComplete !== percentComplete) {
+        this.setState({ percentComplete });
+      }
 
-        if (this.state.percentComplete !== percentComplete) {
-          this.setState({ percentComplete });
-        }
+      if (percentComplete % 20 === 0) {
+        this.rerenderAll();
+      }
+    };
 
-        if (percentComplete % 20 === 0) {
-          this.rerenderAll();
-        }
-      });
-    });
-
-    Promise.all(insertPixelDataPromises).then(() => {
+    const onAllPixelDataInsertedCallback = () => {
       this.rerenderAll();
-    });
+    };
+
+    imageDataObject.onPixelDataInserted(onPixelDataInsertedCallback);
+    imageDataObject.onAllPixelDataInserted(onAllPixelDataInsertedCallback);
 
     return imageDataObject;
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "peerDependencies": {
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "vtk.js": "^11.14.0"
+    "vtk.js": "^11.14.0",
+    "cornerstone-tools": "^4.11.0"
   },
   "dependencies": {
     "date-fns": "^2.2.1",

--- a/src/lib/getImageData.js
+++ b/src/lib/getImageData.js
@@ -69,9 +69,7 @@ export default function getImageData(imageIds, displaySetInstanceUid) {
 
   imageData.setDimensions(xVoxels, yVoxels, zVoxels);
   imageData.setSpacing(xSpacing, ySpacing, zSpacing);
-
   imageData.setDirection(direction);
-
   imageData.setOrigin(...origin);
   imageData.getPointData().setScalars(scalarArray);
 

--- a/src/lib/getImageData.js
+++ b/src/lib/getImageData.js
@@ -75,6 +75,27 @@ export default function getImageData(imageIds, displaySetInstanceUid) {
   imageData.setOrigin(...origin);
   imageData.getPointData().setScalars(scalarArray);
 
+  const _publishPixelDataInserted = count => {
+    imageDataObject.subscriptions.onPixelDataInserted.forEach(callback => {
+      callback(count);
+    });
+  };
+
+  const _publishAllPixelDataInseted = () => {
+    imageDataObject.subscriptions.onAllPixelDataInserted.forEach(callback => {
+      callback();
+    });
+    imageDataObject.isLoading = false;
+    imageDataObject.loaded = true;
+    imageDataObject.vtkImageData.modified();
+
+    // Remove all subscriptions on completion.
+    imageDataObject.subscriptions = {
+      onPixelDataInserted: [],
+      onAllPixelDataInserted: [],
+    };
+  };
+
   const imageDataObject = {
     imageIds,
     metaData0,
@@ -87,6 +108,18 @@ export default function getImageData(imageIds, displaySetInstanceUid) {
     metaDataMap,
     sortedDatasets,
     loaded: false,
+    subscriptions: {
+      onPixelDataInserted: [],
+      onAllPixelDataInserted: [],
+    },
+    onPixelDataInserted: callback => {
+      imageDataObject.subscriptions.onPixelDataInserted.push(callback);
+    },
+    onAllPixelDataInserted: callback => {
+      imageDataObject.subscriptions.onAllPixelDataInserted.push(callback);
+    },
+    _publishPixelDataInserted,
+    _publishAllPixelDataInseted,
   };
 
   imageDataCache.set(displaySetInstanceUid, imageDataObject);


### PR DESCRIPTION
Switched to using the `cornerstone-tools` requestPoolManager, so that we don't send 1000 requests at the same time to the PACS on `imageDataObject.loadImage()`.
    
This is a breaking change, as we the imageDataObject no-longer has insertPixelDataPromises, instead the consumer may subscribe to an imageDataObject's onPixelDataInserted and/or onAllPixelDataInserted hooks. All the relavent  examples have been updated to reflect this. As we are still pre-1.0, I have avoided a major version bump.
