### PR TITLE
Rotatable crosshairs

### DIFF
--- a/examples/App.js
+++ b/examples/App.js
@@ -7,6 +7,7 @@ import VTKMPRPaintingExample from './VTKMPRPaintingExample.js';
 import VTKCornerstonePaintingSyncExample from './VTKCornerstonePaintingSyncExample.js';
 import VTKLoadImageDataExample from './VTKLoadImageDataExample.js';
 import VTKCrosshairsExample from './VTKCrosshairsExample.js';
+import VTKRotatableCrosshairsExample from './VTKRotatableCrosshairsExample.js';
 import VTKMPRRotateExample from './VTKMPRRotateExample.js';
 import VTKVolumeRenderingExample from './VTKVolumeRenderingExample.js';
 
@@ -51,8 +52,7 @@ function Index() {
     {
       title: 'Volume Rendering',
       url: '/volume-rendering',
-      text:
-        'Demonstrates how to perform volume rendering for a CT volume.',
+      text: 'Demonstrates how to perform volume rendering for a CT volume.',
     },
     {
       title: 'Image Segmentation via Paint Widget',
@@ -71,6 +71,12 @@ function Index() {
       url: '/crosshairs',
       text:
         'Demonstrates how to set up the Crosshairs interactor style and SVG Widget',
+    },
+    {
+      title: 'MPR Rotatable Crosshairs Example',
+      url: '/rotatable-crosshairs',
+      text:
+        'Demonstrates how to set up the Rotatable Crosshairs interactor style and SVG Widget',
     },
     {
       title: 'MPR Rotate Example',
@@ -143,8 +149,11 @@ function AppRouter() {
   const synced = () =>
     Example({ children: <VTKCornerstonePaintingSyncExample /> });
   const crosshairs = () => Example({ children: <VTKCrosshairsExample /> });
+  const rotatableCrosshairs = () =>
+    Example({ children: <VTKRotatableCrosshairsExample /> });
   const rotateMPR = () => Example({ children: <VTKMPRRotateExample /> });
-  const volumeRendering = () => Example({ children: <VTKVolumeRenderingExample /> });
+  const volumeRendering = () =>
+    Example({ children: <VTKVolumeRenderingExample /> });
 
   return (
     <Router>
@@ -155,6 +164,11 @@ function AppRouter() {
         <Route exact path="/painting" render={painting} />
         <Route exact path="/cornerstone-sync-painting" render={synced} />
         <Route exact path="/crosshairs" render={crosshairs} />
+        <Route
+          exact
+          path="/rotatable-crosshairs"
+          render={rotatableCrosshairs}
+        />
         <Route exact path="/rotate" render={rotateMPR} />
         <Route exact path="/volume-rendering" render={volumeRendering} />
         <Route exact path="/cornerstone-load-image-data" render={loadImage} />

--- a/examples/VTKRotatableCrosshairsExample.js
+++ b/examples/VTKRotatableCrosshairsExample.js
@@ -4,9 +4,11 @@ import {
   View2D,
   getImageData,
   loadImageData,
-  vtkInteractorStyleRotatableMPRCrosshairs,
   vtkSVGRotatableCrosshairsWidget,
+  vtkInteractorStyleRotatableMPRCrosshairs,
   vtkSVGCrosshairsWidget,
+  vtkInteractorStyleMPRRotate,
+  vtkInteractorStyleMPRSlice,
 } from '@vtk-viewport';
 import { api as dicomwebClientApi } from 'dicomweb-client';
 import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
@@ -65,6 +67,7 @@ class VTKRotatableCrosshairsExample extends Component {
   state = {
     volumes: [],
     displayCrosshairs: true,
+    crosshairsTool: true,
   };
 
   async componentDidMount() {
@@ -118,16 +121,15 @@ class VTKRotatableCrosshairsExample extends Component {
         'rotatableCrosshairsWidget'
       );
 
-      /*
-
       const istyle = vtkInteractorStyleRotatableMPRCrosshairs.newInstance();
 
-      // add istyle
+      // // add istyle
       api.setInteractorStyle({
         istyle,
         configuration: { apis, apiIndex: viewportIndex },
       });
-      */
+
+      //api.setInteractorStyle({ istyle });
 
       // set blend mode to MIP.
       const mapper = api.volumes[0].getMapper();
@@ -165,6 +167,31 @@ class VTKRotatableCrosshairsExample extends Component {
       renderWindow.render();
     });
   }
+
+  toggleTool = () => {
+    let { crosshairsTool } = this.state;
+    const apis = this.apis;
+
+    crosshairsTool = !crosshairsTool;
+
+    apis.forEach((api, apiIndex) => {
+      let istyle;
+
+      if (crosshairsTool) {
+        istyle = vtkInteractorStyleRotatableMPRCrosshairs.newInstance();
+      } else {
+        istyle = vtkInteractorStyleMPRRotate.newInstance();
+      }
+
+      // // add istyle
+      api.setInteractorStyle({
+        istyle,
+        configuration: { apis, apiIndex },
+      });
+    });
+
+    this.setState({ crosshairsTool });
+  };
 
   toggleCrosshairs = () => {
     const { displayCrosshairs } = this.state;
@@ -211,6 +238,11 @@ class VTKRotatableCrosshairsExample extends Component {
                 ? 'Hide Crosshairs'
                 : 'Show Crosshairs'}
             </button>
+            <button onClick={this.toggleTool}>
+              {this.state.crosshairsTool
+                ? 'Switch To Rotate'
+                : 'Switch To Crosshairs'}
+            </button>
           </div>
         </div>
         <div className="row">
@@ -240,19 +272,5 @@ class VTKRotatableCrosshairsExample extends Component {
     );
   }
 }
-
-// Test oblique orientation
-// orientation={{
-//   sliceNormal: [
-//     -0.10828626439623286,
-//     0.9374122377127276,
-//     -0.33095676685864234,
-//   ],
-//   viewUp: [
-//     -0.03670857846736908,
-//     0.32891687750816345,
-//     0.9436451196670532,
-//   ],
-// }}
 
 export default VTKRotatableCrosshairsExample;

--- a/examples/VTKRotatableCrosshairsExample.js
+++ b/examples/VTKRotatableCrosshairsExample.js
@@ -107,6 +107,8 @@ class VTKRotatableCrosshairsExample extends Component {
     return api => {
       this.apis[viewportIndex] = api;
 
+      window.apis = this.apis;
+
       const apis = this.apis;
       const renderWindow = api.genericRenderWindow.getRenderWindow();
 
@@ -238,5 +240,19 @@ class VTKRotatableCrosshairsExample extends Component {
     );
   }
 }
+
+// Test oblique orientation
+// orientation={{
+//   sliceNormal: [
+//     -0.10828626439623286,
+//     0.9374122377127276,
+//     -0.33095676685864234,
+//   ],
+//   viewUp: [
+//     -0.03670857846736908,
+//     0.32891687750816345,
+//     0.9436451196670532,
+//   ],
+// }}
 
 export default VTKRotatableCrosshairsExample;

--- a/examples/VTKRotatableCrosshairsExample.js
+++ b/examples/VTKRotatableCrosshairsExample.js
@@ -6,9 +6,7 @@ import {
   loadImageData,
   vtkSVGRotatableCrosshairsWidget,
   vtkInteractorStyleRotatableMPRCrosshairs,
-  vtkSVGCrosshairsWidget,
-  vtkInteractorStyleMPRRotate,
-  vtkInteractorStyleMPRSlice,
+  vtkInteractorStyleMPRWindowLevel,
 } from '@vtk-viewport';
 import { api as dicomwebClientApi } from 'dicomweb-client';
 import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
@@ -180,7 +178,7 @@ class VTKRotatableCrosshairsExample extends Component {
       if (crosshairsTool) {
         istyle = vtkInteractorStyleRotatableMPRCrosshairs.newInstance();
       } else {
-        istyle = vtkInteractorStyleMPRRotate.newInstance();
+        istyle = vtkInteractorStyleMPRWindowLevel.newInstance();
       }
 
       // // add istyle
@@ -240,7 +238,7 @@ class VTKRotatableCrosshairsExample extends Component {
             </button>
             <button onClick={this.toggleTool}>
               {this.state.crosshairsTool
-                ? 'Switch To Rotate'
+                ? 'Switch To WL/Zoom/Pan/Scroll'
                 : 'Switch To Crosshairs'}
             </button>
           </div>

--- a/examples/VTKRotatableCrosshairsExample.js
+++ b/examples/VTKRotatableCrosshairsExample.js
@@ -1,0 +1,235 @@
+import React from 'react';
+import { Component } from 'react';
+import {
+  View2D,
+  getImageData,
+  loadImageData,
+  vtkInteractorStyleRotatableMPRCrosshairs,
+  vtkRotatableSVGCrosshairsWidget,
+} from '@vtk-viewport';
+import { api as dicomwebClientApi } from 'dicomweb-client';
+import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
+import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
+
+const url = 'https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs';
+const studyInstanceUID =
+  '1.3.6.1.4.1.14519.5.2.1.2744.7002.373729467545468642229382466905';
+const ctSeriesInstanceUID =
+  '1.3.6.1.4.1.14519.5.2.1.2744.7002.182837959725425690842769990419';
+const searchInstanceOptions = {
+  studyInstanceUID,
+};
+
+function loadDataset(imageIds, displaySetInstanceUid) {
+  const imageDataObject = getImageData(imageIds, displaySetInstanceUid);
+
+  loadImageData(imageDataObject);
+  return imageDataObject;
+}
+
+function createStudyImageIds(baseUrl, studySearchOptions) {
+  const SOP_INSTANCE_UID = '00080018';
+  const SERIES_INSTANCE_UID = '0020000E';
+
+  const client = new dicomwebClientApi.DICOMwebClient({ url });
+
+  return new Promise((resolve, reject) => {
+    client.retrieveStudyMetadata(studySearchOptions).then(instances => {
+      const imageIds = instances.map(metaData => {
+        const imageId =
+          `wadors:` +
+          baseUrl +
+          '/studies/' +
+          studyInstanceUID +
+          '/series/' +
+          metaData[SERIES_INSTANCE_UID].Value[0] +
+          '/instances/' +
+          metaData[SOP_INSTANCE_UID].Value[0] +
+          '/frames/1';
+
+        cornerstoneWADOImageLoader.wadors.metaDataManager.add(
+          imageId,
+          metaData
+        );
+
+        return imageId;
+      });
+
+      resolve(imageIds);
+    }, reject);
+  });
+}
+
+class VTKCrosshairsExample extends Component {
+  state = {
+    volumes: [],
+    displayCrosshairs: true,
+  };
+
+  async componentDidMount() {
+    this.apis = [];
+
+    const imageIds = await createStudyImageIds(url, searchInstanceOptions);
+
+    let ctImageIds = imageIds.filter(imageId =>
+      imageId.includes(ctSeriesInstanceUID)
+    );
+
+    const ctImageDataObject = loadDataset(ctImageIds, 'ctDisplaySet');
+
+    const onAllPixelDataInsertedCallback = () => {
+      const ctImageData = ctImageDataObject.vtkImageData;
+
+      const range = ctImageData
+        .getPointData()
+        .getScalars()
+        .getRange();
+
+      const mapper = vtkVolumeMapper.newInstance();
+      const ctVol = vtkVolume.newInstance();
+      const rgbTransferFunction = ctVol.getProperty().getRGBTransferFunction(0);
+
+      mapper.setInputData(ctImageData);
+      mapper.setMaximumSamplesPerRay(2000);
+      rgbTransferFunction.setRange(range[0], range[1]);
+      ctVol.setMapper(mapper);
+
+      this.setState({
+        volumes: [ctVol],
+      });
+    };
+
+    ctImageDataObject.onAllPixelDataInserted(onAllPixelDataInsertedCallback);
+  }
+
+  storeApi = viewportIndex => {
+    return api => {
+      this.apis[viewportIndex] = api;
+
+      const apis = this.apis;
+      const renderWindow = api.genericRenderWindow.getRenderWindow();
+
+      // Add svg widget
+      api.addSVGWidget(
+        vtkRotatableSVGCrosshairsWidget.newInstance(),
+        'rotatableCrosshairsWidget'
+      );
+
+      const istyle = vtkInteractorStyleRotatableMPRCrosshairs.newInstance();
+
+      // add istyle
+      api.setInteractorStyle({
+        istyle,
+        configuration: { apis, apiIndex: viewportIndex },
+      });
+
+      // set blend mode to MIP.
+      const mapper = api.volumes[0].getMapper();
+      if (mapper.setBlendModeToMaximumIntensity) {
+        mapper.setBlendModeToMaximumIntensity();
+      }
+
+      api.setSlabThickness(0.1);
+
+      renderWindow.render();
+
+      // Its up to the layout manager of an app to know how many viewports are being created.
+      if (apis[0] && apis[1] && apis[2]) {
+        //const api = apis[0];
+
+        const api = apis[0];
+
+        api.svgWidgets.crosshairsWidget.resetCrosshairs(apis, 0);
+      }
+    };
+  };
+
+  handleSlabThicknessChange(evt) {
+    const value = evt.target.value;
+    const valueInMM = value / 10;
+    const apis = this.apis;
+
+    apis.forEach(api => {
+      const renderWindow = api.genericRenderWindow.getRenderWindow();
+
+      api.setSlabThickness(valueInMM);
+      renderWindow.render();
+    });
+  }
+
+  toggleCrosshairs = () => {
+    const { displayCrosshairs } = this.state;
+    const apis = this.apis;
+
+    const shouldDisplayCrosshairs = !displayCrosshairs;
+
+    apis.forEach(api => {
+      const { svgWidgetManager, svgWidgets } = api;
+      svgWidgets.crosshairsWidget.setDisplay(shouldDisplayCrosshairs);
+
+      svgWidgetManager.render();
+    });
+
+    this.setState({ displayCrosshairs: shouldDisplayCrosshairs });
+  };
+
+  render() {
+    if (!this.state.volumes || !this.state.volumes.length) {
+      return <h4>Loading...</h4>;
+    }
+
+    return (
+      <>
+        <div className="row">
+          <div className="col-xs-4">
+            <p>
+              This example demonstrates how to use the Crosshairs manipulator.
+            </p>
+            <label htmlFor="set-slab-thickness">SlabThickness: </label>
+            <input
+              id="set-slab-thickness"
+              type="range"
+              name="points"
+              min="1"
+              max="5000"
+              onChange={this.handleSlabThicknessChange.bind(this)}
+            />
+          </div>
+          <div className="col-xs-4">
+            <p>Click bellow to toggle crosshairs on/off.</p>
+            <button onClick={this.toggleCrosshairs}>
+              {this.state.displayCrosshairs
+                ? 'Hide Crosshairs'
+                : 'Show Crosshairs'}
+            </button>
+          </div>
+        </div>
+        <div className="row">
+          <div className="col-sm-4">
+            <View2D
+              volumes={this.state.volumes}
+              onCreated={this.storeApi(0)}
+              orientation={{ sliceNormal: [0, 1, 0], viewUp: [0, 0, 1] }}
+            />
+          </div>
+          <div className="col-sm-4">
+            <View2D
+              volumes={this.state.volumes}
+              onCreated={this.storeApi(1)}
+              orientation={{ sliceNormal: [1, 0, 0], viewUp: [0, 0, 1] }}
+            />
+          </div>
+          <div className="col-sm-4">
+            <View2D
+              volumes={this.state.volumes}
+              onCreated={this.storeApi(2)}
+              orientation={{ sliceNormal: [0, 0, 1], viewUp: [0, -1, 0] }}
+            />
+          </div>
+        </div>
+      </>
+    );
+  }
+}
+
+export default VTKCrosshairsExample;

--- a/examples/VTKRotatableCrosshairsExample.js
+++ b/examples/VTKRotatableCrosshairsExample.js
@@ -249,6 +249,7 @@ class VTKRotatableCrosshairsExample extends Component {
               volumes={this.state.volumes}
               onCreated={this.storeApi(0)}
               orientation={{ sliceNormal: [0, 1, 0], viewUp: [0, 0, 1] }}
+              showRotation={true}
             />
           </div>
           <div className="col-sm-4">
@@ -256,6 +257,7 @@ class VTKRotatableCrosshairsExample extends Component {
               volumes={this.state.volumes}
               onCreated={this.storeApi(1)}
               orientation={{ sliceNormal: [1, 0, 0], viewUp: [0, 0, 1] }}
+              showRotation={true}
             />
           </div>
           <div className="col-sm-4">
@@ -263,6 +265,7 @@ class VTKRotatableCrosshairsExample extends Component {
               volumes={this.state.volumes}
               onCreated={this.storeApi(2)}
               orientation={{ sliceNormal: [0, 0, 1], viewUp: [0, -1, 0] }}
+              showRotation={true}
             />
           </div>
         </div>

--- a/examples/VTKRotatableCrosshairsExample.js
+++ b/examples/VTKRotatableCrosshairsExample.js
@@ -5,7 +5,8 @@ import {
   getImageData,
   loadImageData,
   vtkInteractorStyleRotatableMPRCrosshairs,
-  vtkRotatableSVGCrosshairsWidget,
+  vtkSVGRotatableCrosshairsWidget,
+  vtkSVGCrosshairsWidget,
 } from '@vtk-viewport';
 import { api as dicomwebClientApi } from 'dicomweb-client';
 import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
@@ -60,7 +61,7 @@ function createStudyImageIds(baseUrl, studySearchOptions) {
   });
 }
 
-class VTKCrosshairsExample extends Component {
+class VTKRotatableCrosshairsExample extends Component {
   state = {
     volumes: [],
     displayCrosshairs: true,
@@ -109,11 +110,13 @@ class VTKCrosshairsExample extends Component {
       const apis = this.apis;
       const renderWindow = api.genericRenderWindow.getRenderWindow();
 
-      // Add svg widget
+      // Add rotatable svg widget
       api.addSVGWidget(
-        vtkRotatableSVGCrosshairsWidget.newInstance(),
+        vtkSVGRotatableCrosshairsWidget.newInstance(),
         'rotatableCrosshairsWidget'
       );
+
+      /*
 
       const istyle = vtkInteractorStyleRotatableMPRCrosshairs.newInstance();
 
@@ -122,6 +125,7 @@ class VTKCrosshairsExample extends Component {
         istyle,
         configuration: { apis, apiIndex: viewportIndex },
       });
+      */
 
       // set blend mode to MIP.
       const mapper = api.volumes[0].getMapper();
@@ -135,11 +139,14 @@ class VTKCrosshairsExample extends Component {
 
       // Its up to the layout manager of an app to know how many viewports are being created.
       if (apis[0] && apis[1] && apis[2]) {
-        //const api = apis[0];
-
         const api = apis[0];
 
-        api.svgWidgets.crosshairsWidget.resetCrosshairs(apis, 0);
+        apis.forEach((api, index) => {
+          api.svgWidgets.rotatableCrosshairsWidget.setApiIndex(index);
+          api.svgWidgets.rotatableCrosshairsWidget.setApis(apis);
+        });
+
+        api.svgWidgets.rotatableCrosshairsWidget.resetCrosshairs(apis, 0);
       }
     };
   };
@@ -165,7 +172,7 @@ class VTKCrosshairsExample extends Component {
 
     apis.forEach(api => {
       const { svgWidgetManager, svgWidgets } = api;
-      svgWidgets.crosshairsWidget.setDisplay(shouldDisplayCrosshairs);
+      svgWidgets.rotatableCrosshairsWidget.setDisplay(shouldDisplayCrosshairs);
 
       svgWidgetManager.render();
     });
@@ -232,4 +239,4 @@ class VTKCrosshairsExample extends Component {
   }
 }
 
-export default VTKCrosshairsExample;
+export default VTKRotatableCrosshairsExample;

--- a/src/VTKViewport/View2D.js
+++ b/src/VTKViewport/View2D.js
@@ -41,7 +41,7 @@ export default class View2D extends Component {
       visible: true,
       renderOutline: true,
       segmentsDefaultProperties: [],
-      onNewSegmentationRequested: () => { }
+      onNewSegmentationRequested: () => {},
     },
   };
 
@@ -61,7 +61,7 @@ export default class View2D extends Component {
     };
     this.interactorStyleSubs = [];
     this.state = {
-      voi: this.getVOI(props.volumes[0])
+      voi: this.getVOI(props.volumes[0]),
     };
 
     this.apiProperties = {};
@@ -200,6 +200,8 @@ export default class View2D extends Component {
 
     const boundUpdateVOI = this.updateVOI.bind(this);
     const boundGetOrienation = this.getOrientation.bind(this);
+    const boundGetViewUp = this.getViewUp.bind(this);
+    const boundGetSliceNormal = this.getSliceNormal.bind(this);
     const boundSetInteractorStyle = this.setInteractorStyle.bind(this);
     const boundGetSlabThickness = this.getSlabThickness.bind(this);
     const boundSetSlabThickness = this.setSlabThickness.bind(this);
@@ -241,6 +243,8 @@ export default class View2D extends Component {
         updateImage: boundUpdateImage,
         updateVOI: boundUpdateVOI,
         getOrientation: boundGetOrienation,
+        getViewUp: boundGetViewUp,
+        getSliceNormal: boundGetSliceNormal,
         setInteractorStyle: boundSetInteractorStyle,
         getSlabThickness: boundGetSlabThickness,
         setSlabThickness: boundSetSlabThickness,
@@ -260,6 +264,20 @@ export default class View2D extends Component {
 
       this.props.onCreated(api);
     }
+  }
+
+  getViewUp() {
+    const renderWindow = this.genericRenderWindow.getRenderWindow();
+    const currentIStyle = renderWindow.getInteractor().getInteractorStyle();
+
+    return currentIStyle.getViewUp();
+  }
+
+  getSliceNormal() {
+    const renderWindow = this.genericRenderWindow.getRenderWindow();
+    const currentIStyle = renderWindow.getInteractor().getInteractorStyle();
+
+    return currentIStyle.getSliceNormal();
   }
 
   getApiProperty(propertyName) {
@@ -478,7 +496,7 @@ export default class View2D extends Component {
 
     if (
       prevProps.paintFilterLabelMapImageData !==
-      this.props.paintFilterLabelMapImageData &&
+        this.props.paintFilterLabelMapImageData &&
       this.props.paintFilterLabelMapImageData
     ) {
       this.subs.labelmap.unsubscribe();
@@ -510,12 +528,13 @@ export default class View2D extends Component {
 
       this.labelmap = labelmap;
 
-      this.props.labelmapRenderingOptions.segmentsDefaultProperties
-        .forEach((properties, segmentNumber) => {
+      this.props.labelmapRenderingOptions.segmentsDefaultProperties.forEach(
+        (properties, segmentNumber) => {
           if (properties) {
             this.setSegmentVisibility(segmentNumber, properties.visible);
           }
-        });
+        }
+      );
 
       // Add actors.
       if (this.labelmap && this.labelmap.actor) {
@@ -544,7 +563,7 @@ export default class View2D extends Component {
     if (
       prevProps.labelmapRenderingOptions &&
       prevProps.labelmapRenderingOptions.visible !==
-      this.props.labelmapRenderingOptions.visible
+        this.props.labelmapRenderingOptions.visible
     ) {
       this.labelmap.actor.setVisibility(
         prevProps.labelmapRenderingOptions.visible

--- a/src/VTKViewport/View2D.js
+++ b/src/VTKViewport/View2D.js
@@ -200,6 +200,7 @@ export default class View2D extends Component {
 
     const boundUpdateVOI = this.updateVOI.bind(this);
     const boundGetOrienation = this.getOrientation.bind(this);
+    const boundSetOrientation = this.setOrientation.bind(this);
     const boundGetViewUp = this.getViewUp.bind(this);
     const boundGetSliceNormal = this.getSliceNormal.bind(this);
     const boundSetInteractorStyle = this.setInteractorStyle.bind(this);
@@ -243,6 +244,7 @@ export default class View2D extends Component {
         updateImage: boundUpdateImage,
         updateVOI: boundUpdateVOI,
         getOrientation: boundGetOrienation,
+        setOrientation: boundSetOrientation,
         getViewUp: boundGetViewUp,
         getSliceNormal: boundGetSliceNormal,
         setInteractorStyle: boundSetInteractorStyle,
@@ -278,6 +280,13 @@ export default class View2D extends Component {
     const currentIStyle = renderWindow.getInteractor().getInteractorStyle();
 
     return currentIStyle.getSliceNormal();
+  }
+
+  setOrientation(sliceNormal, viewUp) {
+    const renderWindow = this.genericRenderWindow.getRenderWindow();
+    const currentIStyle = renderWindow.getInteractor().getInteractorStyle();
+
+    currentIStyle.setSliceOrientation(sliceNormal, viewUp);
   }
 
   getApiProperty(propertyName) {

--- a/src/VTKViewport/View2D.js
+++ b/src/VTKViewport/View2D.js
@@ -58,6 +58,7 @@ export default class View2D extends Component {
     this.genericRenderWindow = null;
     this.widgetManager = vtkWidgetManager.newInstance();
     this.container = React.createRef();
+
     this.subs = {
       interactor: createSub(),
       data: createSub(),

--- a/src/VTKViewport/View2D.js
+++ b/src/VTKViewport/View2D.js
@@ -299,7 +299,7 @@ export default class View2D extends Component {
     const renderWindow = this.genericRenderWindow.getRenderWindow();
     const currentIStyle = renderWindow.getInteractor().getInteractorStyle();
 
-    this.updateRotationRelativeToOrientation(sliceNormal, viewUp);
+    this.updateRotationRelativeToOrientation(sliceNormal);
 
     currentIStyle.setSliceOrientation(sliceNormal, viewUp);
   }
@@ -426,26 +426,9 @@ export default class View2D extends Component {
     this.setState({ rotation: { theta, phi } });
   }
 
-  updateRotationRelativeToOrientation(newNormal, newViewUp) {
+  updateRotationRelativeToOrientation(newNormal) {
     const { orientation } = this.props;
-    const {
-      sliceNormal: originalSliceNormal,
-      viewUp: originalViewUp,
-    } = orientation;
-
-    // const dotNormalOntoOldNormal = vec2.dot(newNormal, originalSliceNormal);
-
-    // const newNormalProjectedOnOriginalNormal = [
-    //   dotNormalOntoOldNormal * originalSliceNormal[0],
-    //   dotNormalOntoOldNormal * originalSliceNormal[1],
-    //   dotNormalOntoOldNormal * originalSliceNormal[2],
-    // ];
-
-    // const normalFlattenedToViewUp = [
-    //   newNormal[0] - newNormalProjectedOnOriginalNormal[0],
-    //   newNormal[1] - newNormalProjectedOnOriginalNormal[1],
-    //   newNormal[2] - newNormalProjectedOnOriginalNormal[2],
-    // ];
+    const { sliceNormal: originalSliceNormal } = orientation;
 
     // convert to spherical coords;
 

--- a/src/VTKViewport/vtkInteractorStyleMPRSlice.js
+++ b/src/VTKViewport/vtkInteractorStyleMPRSlice.js
@@ -246,7 +246,12 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
 
       const api = apis[apiIndex];
 
-      api.svgWidgets.crosshairsWidget.updateCrosshairForApi(api);
+      if (api.svgWidgets.crosshairsWidget) {
+        api.svgWidgets.crosshairsWidget.updateCrosshairForApi(api);
+      }
+      if (api.svgWidgets.rotatableCrosshairsWidget) {
+        api.svgWidgets.rotatableCrosshairsWidget.updateCrosshairForApi(api);
+      }
     }
   }
 
@@ -270,7 +275,13 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
       const { apis, apiIndex } = model;
       const api = apis[apiIndex];
 
-      api.svgWidgets.crosshairsWidget.updateCrosshairForApi(api);
+      // TODO -> This is kinda bad but the only way with the current setup.
+      if (api.svgWidgets.crosshairsWidget) {
+        api.svgWidgets.crosshairsWidget.updateCrosshairForApi(api);
+      }
+      if (api.svgWidgets.rotatableCrosshairsWidget) {
+        api.svgWidgets.rotatableCrosshairsWidget.updateCrosshairForApi(api);
+      }
     }
   };
 
@@ -280,7 +291,12 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
       const { apis, apiIndex } = model;
       const api = apis[apiIndex];
 
-      api.svgWidgets.crosshairsWidget.updateCrosshairForApi(api);
+      if (api.svgWidgets.crosshairsWidget) {
+        api.svgWidgets.crosshairsWidget.updateCrosshairForApi(api);
+      }
+      if (api.svgWidgets.rotatableCrosshairsWidget) {
+        api.svgWidgets.rotatableCrosshairsWidget.updateCrosshairForApi(api);
+      }
     }
 
     superButtonRelease();
@@ -367,7 +383,10 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
 
       const api = apis[apiIndex];
 
-      if (!api.svgWidgets.crosshairsWidget) {
+      if (
+        !api.svgWidgets.crosshairsWidget &&
+        !api.svgWidgets.rotatableCrosshairsWidget
+      ) {
         // If we aren't using the crosshairs widget, bail out early.
         return;
       }
@@ -407,7 +426,20 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
         worldPos[i] += halfSlabThickness * directionOfProjection[i];
       }
 
-      api.svgWidgets.crosshairsWidget.moveCrosshairs(worldPos, apis, apiIndex);
+      if (api.svgWidgets.crosshairsWidget) {
+        api.svgWidgets.crosshairsWidget.moveCrosshairs(
+          worldPos,
+          apis,
+          apiIndex
+        );
+      }
+      if (api.svgWidgets.rotatableCrosshairsWidget) {
+        api.svgWidgets.rotatableCrosshairsWidget.moveCrosshairs(
+          worldPos,
+          apis,
+          apiIndex
+        );
+      }
     }
   };
 

--- a/src/VTKViewport/vtkInteractorStyleRotatableMPRCrosshairs.js
+++ b/src/VTKViewport/vtkInteractorStyleRotatableMPRCrosshairs.js
@@ -318,8 +318,6 @@ function vtkInteractorStyleRotatableMPRCrosshairs(publicAPI, model) {
       selectedLines[1] = true;
     }
 
-    console.log(selectedLines);
-
     lines.forEach((line, index) => {
       const selected = selectedLines[index];
 
@@ -331,7 +329,6 @@ function vtkInteractorStyleRotatableMPRCrosshairs(publicAPI, model) {
     });
 
     if (shouldUpdate) {
-      console.log(shouldUpdate);
       updateCrosshairs(callData);
     }
   }

--- a/src/VTKViewport/vtkInteractorStyleRotatableMPRCrosshairs.js
+++ b/src/VTKViewport/vtkInteractorStyleRotatableMPRCrosshairs.js
@@ -1,0 +1,116 @@
+import macro from 'vtk.js/Sources/macro';
+import vtkInteractorStyleMPRSlice from './vtkInteractorStyleMPRSlice.js';
+import Constants from 'vtk.js/Sources/Rendering/Core/InteractorStyle/Constants';
+import vtkCoordinate from 'vtk.js/Sources/Rendering/Core/Coordinate';
+
+const { States } = Constants;
+
+// ----------------------------------------------------------------------------
+// Global methods
+// ----------------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------
+// vtkInteractorStyleRotatableMPRCrosshairs methods
+// ----------------------------------------------------------------------------
+
+function vtkInteractorStyleRotatableMPRCrosshairs(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkInteractorStyleRotatableMPRCrosshairs');
+
+  function moveCrosshairs(callData) {
+    const { apis, apiIndex } = model;
+    const api = apis[apiIndex];
+
+    const pos = callData.position;
+    const renderer = callData.pokedRenderer;
+
+    const dPos = vtkCoordinate.newInstance();
+    dPos.setCoordinateSystemToDisplay();
+
+    dPos.setValue(pos.x, pos.y, 0);
+    let worldPos = dPos.getComputedWorldValue(renderer);
+
+    const camera = renderer.getActiveCamera();
+    const directionOfProjection = camera.getDirectionOfProjection();
+
+    const halfSlabThickness = api.getSlabThickness() / 2;
+
+    // Add half of the slab thickness to the world position, such that we select
+    // The center of the slice.
+
+    for (let i = 0; i < worldPos.length; i++) {
+      worldPos[i] += halfSlabThickness * directionOfProjection[i];
+    }
+
+    api.svgWidgets.crosshairsWidget.moveCrosshairs(worldPos, apis, apiIndex);
+
+    publicAPI.invokeInteractionEvent({ type: 'InteractionEvent' });
+  }
+
+  const superHandleMouseMove = publicAPI.handleMouseMove;
+  publicAPI.handleMouseMove = callData => {
+    if (model.state === States.IS_WINDOW_LEVEL) {
+      moveCrosshairs(callData);
+    }
+
+    if (superHandleMouseMove) {
+      superHandleMouseMove(callData);
+    }
+  };
+
+  const superHandleLeftButtonPress = publicAPI.handleLeftButtonPress;
+  publicAPI.handleLeftButtonPress = callData => {
+    if (!callData.shiftKey && !callData.controlKey) {
+      if (model.volumeActor) {
+        moveCrosshairs(callData);
+        publicAPI.startWindowLevel();
+      }
+    } else if (superHandleLeftButtonPress) {
+      superHandleLeftButtonPress(callData);
+    }
+  };
+
+  publicAPI.superHandleLeftButtonRelease = publicAPI.handleLeftButtonRelease;
+  publicAPI.handleLeftButtonRelease = () => {
+    switch (model.state) {
+      case States.IS_WINDOW_LEVEL:
+        publicAPI.endWindowLevel();
+        break;
+
+      default:
+        publicAPI.superHandleLeftButtonRelease();
+        break;
+    }
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  // Inheritance
+  vtkInteractorStyleMPRSlice.extend(publicAPI, model, initialValues);
+
+  macro.setGet(publicAPI, model, ['callback', 'apis', 'apiIndex', 'onScroll']);
+
+  // Object specific methods
+  vtkInteractorStyleRotatableMPRCrosshairs(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(
+  extend,
+  'vtkInteractorStyleRotatableMPRCrosshairs'
+);
+
+// ----------------------------------------------------------------------------
+
+export default Object.assign({ newInstance, extend });

--- a/src/VTKViewport/vtkInteractorStyleRotatableMPRCrosshairs.js
+++ b/src/VTKViewport/vtkInteractorStyleRotatableMPRCrosshairs.js
@@ -42,7 +42,11 @@ function vtkInteractorStyleRotatableMPRCrosshairs(publicAPI, model) {
       worldPos[i] += halfSlabThickness * directionOfProjection[i];
     }
 
-    api.svgWidgets.crosshairsWidget.moveCrosshairs(worldPos, apis, apiIndex);
+    api.svgWidgets.rotatableCrosshairsWidget.moveCrosshairs(
+      worldPos,
+      apis,
+      apiIndex
+    );
 
     publicAPI.invokeInteractionEvent({ type: 'InteractionEvent' });
   }

--- a/src/VTKViewport/vtkInteractorStyleRotatableMPRCrosshairs.js
+++ b/src/VTKViewport/vtkInteractorStyleRotatableMPRCrosshairs.js
@@ -165,6 +165,8 @@ function vtkInteractorStyleRotatableMPRCrosshairs(publicAPI, model) {
     const sliceNormal = thisApi.getSliceNormal();
     const axis = [-sliceNormal[0], -sliceNormal[1], -sliceNormal[2]];
 
+    const { matrix } = vtkMatrixBuilder.buildFromRadian().rotate(angle, axis);
+
     // Rotate other apis
     apis.forEach((api, index) => {
       if (index !== apiIndex) {
@@ -176,18 +178,8 @@ function vtkInteractorStyleRotatableMPRCrosshairs(publicAPI, model) {
         const newSliceNormalForApi = [];
         const newViewUpForApi = [];
 
-        const rotationQuat = quat.create();
-
-        quat.setAxisAngle(rotationQuat, axis, angle);
-        quat.normalize(rotationQuat, rotationQuat);
-
-        // rotate the ViewUp with the rotation
-        vec3.transformQuat(newViewUpForApi, viewUpForApi, rotationQuat);
-        vec3.transformQuat(
-          newSliceNormalForApi,
-          sliceNormalForApi,
-          rotationQuat
-        );
+        vec3.transformMat4(newSliceNormalForApi, sliceNormalForApi, matrix);
+        vec3.transformMat4(newViewUpForApi, viewUpForApi, matrix);
 
         api.setOrientation(newSliceNormalForApi, newViewUpForApi);
       }

--- a/src/VTKViewport/vtkSVGCrosshairsWidget.js
+++ b/src/VTKViewport/vtkSVGCrosshairsWidget.js
@@ -140,10 +140,7 @@ function vtkSVGCrosshairsWidget(publicAPI, model) {
   };
 
   publicAPI.moveCrosshairs = (worldPos, apis) => {
-    if (
-      worldPos === undefined ||
-      apis === undefined
-    ) {
+    if (worldPos === undefined || apis === undefined) {
       console.error(
         'worldPos, apis must be defined in order to update crosshairs.'
       );

--- a/src/VTKViewport/vtkSVGRotatableCrosshairsWidget copy.js
+++ b/src/VTKViewport/vtkSVGRotatableCrosshairsWidget copy.js
@@ -1,0 +1,262 @@
+import macro from 'vtk.js/Sources/macro';
+import vtkMatrixBuilder from 'vtk.js/Sources/Common/Core/MatrixBuilder';
+import vtkCoordinate from 'vtk.js/Sources/Rendering/Core/Coordinate';
+
+let instanceId = 1;
+
+function getWidgetNode(svgContainer, widgetId) {
+  let node = svgContainer.querySelector(`#${widgetId}`);
+  if (!node) {
+    node = document.createElement('g');
+    node.setAttribute('id', widgetId);
+    svgContainer.appendChild(node);
+  }
+  return node;
+}
+
+// ----------------------------------------------------------------------------
+
+function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
+  model.classHierarchy.push('vtkSVGCrosshairsWidget');
+  model.widgetId = `vtkSVGCrosshairsWidget-${instanceId++}`;
+
+  publicAPI.render = (svgContainer, scale) => {
+    const node = getWidgetNode(svgContainer, model.widgetId);
+    const { point, strokeColor, strokeWidth, strokeDashArray, padding } = model;
+    if (point[0] === null || point[1] === null) {
+      return;
+    }
+
+    const width = parseInt(svgContainer.getAttribute('width'), 10);
+    const height = parseInt(svgContainer.getAttribute('height'), 10);
+    // Unused
+    // const widthScale = svgContainer.getBoundingClientRect().width / width;
+    // const heightScale = svgContainer.getBoundingClientRect().height / height;
+    // const widthClient = svgContainer.getBoundingClientRect().width;
+    // const heightClient = svgContainer.getBoundingClientRect().height;
+
+    const p = point.slice();
+    p[0] = point[0] * scale;
+    p[1] = height - point[1] * scale;
+
+    const left = [0, height / scale / 2];
+    const top = [width / scale / 2, 0];
+    const right = [width / scale, height / scale / 2];
+    const bottom = [width / scale / 2, height / scale];
+
+    if (model.display) {
+      node.innerHTML = `
+      <g id="container" fill-opacity="1" stroke-dasharray="none" stroke="none" stroke-opacity="1" fill="none">
+       <g>
+       <!-- TODO: Why is this <svg> necessary?? </svg> If I don't include it, nothing renders !-->
+       <svg version="1.1" viewBox="0 0 ${width} ${height}" width=${width} height=${height} style="width: 100%; height: 100%">
+       <!-- Top !-->
+        <line
+          x1="${p[0]}"
+          y1="${top[1]}"
+          x2="${p[0]}"
+          y2="${p[1] - padding}"
+          stroke="${strokeColor}"
+          stroke-dasharray="${strokeDashArray}"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="${strokeWidth}"
+        ></line>
+        <!-- Right !-->
+        <line
+          x1="${right[0]}"
+          y1="${p[1]}"
+          x2="${p[0] + padding}"
+          y2="${p[1]}"
+          stroke-dasharray="${strokeDashArray}"
+          stroke="${strokeColor}"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width=${strokeWidth}
+        ></line>
+        <!-- Bottom !-->
+        <line
+          x1="${p[0]}"
+          y1="${bottom[1]}"
+          x2="${p[0]}"
+          y2="${p[1] + padding}"
+          stroke-dasharray="${strokeDashArray}"
+          stroke="${strokeColor}"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width=${strokeWidth}
+        ></line>
+        <!-- Left !-->
+        <line
+          x1="${left[0]}"
+          y1="${p[1]}"
+          x2="${p[0] - padding}"
+          y2="${p[1]}"
+          stroke-dasharray="${strokeDashArray}"
+          stroke="${strokeColor}"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width=${strokeWidth}
+        ></line>
+       </g>
+      </g>
+            `;
+    } else {
+      node.innerHTML = '';
+    }
+  };
+
+  publicAPI.resetCrosshairs = (apis, apiIndex) => {
+    const api = apis[apiIndex];
+
+    if (!api.svgWidgets.crosshairsWidget) {
+      // If we aren't using the crosshairs widget, bail out early.
+      return;
+    }
+
+    // Get viewport and get its center.
+    const renderer = api.genericRenderWindow.getRenderer();
+    const view = renderer.getRenderWindow().getViews()[0];
+    const dims = view.getViewportSize(renderer);
+    const dPos = vtkCoordinate.newInstance();
+
+    dPos.setCoordinateSystemToDisplay();
+
+    dPos.setValue(0.5 * dims[0], 0.5 * dims[1], 0);
+    let worldPos = dPos.getComputedWorldValue(renderer);
+
+    const camera = renderer.getActiveCamera();
+    const directionOfProjection = camera.getDirectionOfProjection();
+    const halfSlabThickness = api.getSlabThickness() / 2;
+
+    // Add half of the slab thickness to the world position, such that we select
+    //The center of the slice.
+
+    for (let i = 0; i < worldPos.length; i++) {
+      worldPos[i] += halfSlabThickness * directionOfProjection[i];
+    }
+
+    publicAPI.moveCrosshairs(worldPos, apis);
+  };
+
+  publicAPI.moveCrosshairs = (worldPos, apis) => {
+    if (worldPos === undefined || apis === undefined) {
+      console.error(
+        'worldPos, apis must be defined in order to update crosshairs.'
+      );
+    }
+
+    // Set camera focal point to world coordinate for linked views
+    apis.forEach((api, viewportIndex) => {
+      api.set('cachedCrosshairWorldPosition', worldPos);
+
+      // We are basically doing the same as getSlice but with the world coordinate
+      // that we want to jump to instead of the camera focal point.
+      // I would rather do the camera adjustment directly but I keep
+      // doing it wrong and so this is good enough for now.
+      const renderWindow = api.genericRenderWindow.getRenderWindow();
+
+      const istyle = renderWindow.getInteractor().getInteractorStyle();
+      const sliceNormal = istyle.getSliceNormal();
+      const transform = vtkMatrixBuilder
+        .buildFromDegree()
+        .identity()
+        .rotateFromDirections(sliceNormal, [1, 0, 0]);
+
+      const mutatedWorldPos = worldPos.slice();
+      transform.apply(mutatedWorldPos);
+      const slice = mutatedWorldPos[0];
+
+      istyle.setSlice(slice);
+
+      renderWindow.render();
+
+      const renderer = api.genericRenderWindow.getRenderer();
+      const wPos = vtkCoordinate.newInstance();
+      wPos.setCoordinateSystemToWorld();
+      wPos.setValue(...worldPos);
+
+      const displayPosition = wPos.getComputedDisplayValue(renderer);
+
+      const { svgWidgetManager } = api;
+      api.svgWidgets.crosshairsWidget.setPoint(
+        displayPosition[0],
+        displayPosition[1]
+      );
+
+      svgWidgetManager.render();
+    });
+  };
+
+  publicAPI.updateCrosshairForApi = api => {
+    if (!api.svgWidgets.crosshairsWidget) {
+      // If we aren't using the crosshairs widget, bail out early.
+      return;
+    }
+
+    const renderer = api.genericRenderWindow.getRenderer();
+    let cachedCrosshairWorldPosition = api.get('cachedCrosshairWorldPosition');
+
+    const wPos = vtkCoordinate.newInstance();
+    wPos.setCoordinateSystemToWorld();
+    wPos.setValue(...cachedCrosshairWorldPosition);
+
+    const doubleDisplayPosition = wPos.getComputedDoubleDisplayValue(renderer);
+
+    const dPos = vtkCoordinate.newInstance();
+    dPos.setCoordinateSystemToDisplay();
+
+    dPos.setValue(doubleDisplayPosition[0], doubleDisplayPosition[1], 0);
+    let worldPos = dPos.getComputedWorldValue(renderer);
+
+    const camera = renderer.getActiveCamera();
+    const directionOfProjection = camera.getDirectionOfProjection();
+    const halfSlabThickness = api.getSlabThickness() / 2;
+
+    // Add half of the slab thickness to the world position, such that we select
+    //The center of the slice.
+
+    for (let i = 0; i < worldPos.length; i++) {
+      worldPos[i] += halfSlabThickness * directionOfProjection[i];
+    }
+
+    publicAPI.moveCrosshairs(worldPos, [api]);
+  };
+}
+
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  point: [null, null],
+  strokeColor: '#00ff00',
+  strokeWidth: 1,
+  strokeDashArray: '',
+  padding: 20,
+  display: true,
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  macro.obj(publicAPI, model);
+  macro.get(publicAPI, model, ['widgetId']);
+  macro.setGet(publicAPI, model, [
+    'strokeColor',
+    'strokeWidth',
+    'strokeDashArray',
+    'display',
+  ]);
+  macro.setGetArray(publicAPI, model, ['point', 'padding'], 2);
+
+  vtkSVGCrosshairsWidget(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend, 'vtkSVGCrosshairsWidget');
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/src/VTKViewport/vtkSVGRotatableCrosshairsWidget.js
+++ b/src/VTKViewport/vtkSVGRotatableCrosshairsWidget.js
@@ -71,9 +71,9 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
         // get a point in the plane.
         // Need a distant world position or we get rounding errors when mapping to screen and don't get nice right angles.
         const referenceWorldPointInPlane = [
-          crosshairWorldPosition[0] + (viewUp[0] + xAxis[0]) * 100000,
-          crosshairWorldPosition[1] + (viewUp[1] + xAxis[1]) * 100000,
-          crosshairWorldPosition[2] + (viewUp[2] + xAxis[2]) * 100000,
+          crosshairWorldPosition[0] + (viewUp[0] + xAxis[0]) * 1000000,
+          crosshairWorldPosition[1] + (viewUp[1] + xAxis[1]) * 1000000,
+          crosshairWorldPosition[2] + (viewUp[2] + xAxis[2]) * 1000000,
         ];
 
         // thisApi as we want to map it to the displayPosition of THIS api.
@@ -100,13 +100,12 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
           p[1] - unitVectorFromCenter[1] * farDistance,
         ];
 
-        // [xmin, ymin, xmax, ymax]
         liangBarksyClip(negativeDistantPoint, distantPoint, [
-          left,
-          top,
-          right,
-          bottom,
-        ]); // returns 1 - "clipped"
+          left, //xmin
+          top, // ymin
+          right, // xmax
+          bottom, // ymax
+        ]);
 
         const referenceLine = {
           points: [
@@ -132,14 +131,13 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
 
   publicAPI.render = (svgContainer, scale) => {
     const node = getWidgetNode(svgContainer, model.widgetId);
-    const {
+    let {
       point,
       strokeColors,
       strokeWidth,
       strokeDashArray,
       apis,
       apiIndex,
-      centerRadius,
     } = model;
     if (point[0] === null || point[1] === null) {
       return;
@@ -171,6 +169,14 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
       secondLine,
       p
     );
+
+    const testMouseOver = () => {
+      console.log('TEST');
+      debugger;
+    };
+
+    // onmouseover="this.style.stroke='#FFF'"
+    // onmouseout="this.style.stroke='${referenceLines[0].color}'"
 
     if (model.display) {
       node.innerHTML = `
@@ -335,7 +341,7 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
       wPos.setCoordinateSystemToWorld();
       wPos.setValue(...worldPos);
 
-      const displayPosition = wPos.getComputedDisplayValue(renderer);
+      const displayPosition = wPos.getComputedDoubleDisplayValue(renderer);
 
       const { svgWidgetManager } = api;
       api.svgWidgets.rotatableCrosshairsWidget.setPoint(

--- a/src/VTKViewport/vtkSVGRotatableCrosshairsWidget.js
+++ b/src/VTKViewport/vtkSVGRotatableCrosshairsWidget.js
@@ -172,10 +172,6 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
       p
     );
 
-    debugger;
-
-    debugger;
-
     if (model.display) {
       node.innerHTML = `
       <g id="container" fill-opacity="1" stroke-dasharray="none" stroke="none" stroke-opacity="1" fill="none">

--- a/src/VTKViewport/vtkSVGRotatableCrosshairsWidget.js
+++ b/src/VTKViewport/vtkSVGRotatableCrosshairsWidget.js
@@ -22,8 +22,8 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
   model.classHierarchy.push('vtkSVGRotatableCrosshairsWidget');
   model.widgetId = `vtkSVGRotatableCrosshairsWidget-${instanceId++}`;
 
-  model.calculateReferenceLines = () => {
-    const { point, strokeColors, apis, apiIndex } = model;
+  model.calculateReferenceLines = (apiIndex, point) => {
+    const { strokeColors, apis } = model;
     if (point[0] === null || point[1] === null) {
       return;
     }
@@ -33,8 +33,6 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
     const { svgWidgetManager } = thisApi;
     const [width, height] = svgWidgetManager.getSize();
     const scale = svgWidgetManager.getScale();
-
-    debugger;
 
     const p = point.slice();
 
@@ -145,13 +143,9 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
       return;
     }
 
-    // TODO Move out of render function
-    model.calculateReferenceLines();
-
     const thisApi = apis[apiIndex];
     const referenceLines = thisApi.svgWidgets.rotatableCrosshairsWidget.getReferenceLines();
 
-    debugger;
     const width = parseInt(svgContainer.getAttribute('width'), 10);
     const height = parseInt(svgContainer.getAttribute('height'), 10);
 
@@ -239,7 +233,7 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
     }
 
     // Set camera focal point to world coordinate for linked views
-    apis.forEach((api, viewportIndex) => {
+    apis.forEach((api, apiIndex) => {
       api.set('cachedCrosshairWorldPosition', worldPos);
 
       // We are basically doing the same as getSlice but with the world coordinate
@@ -275,6 +269,8 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
         displayPosition[0],
         displayPosition[1]
       );
+
+      model.calculateReferenceLines(apiIndex, displayPosition);
 
       svgWidgetManager.render();
     });
@@ -324,6 +320,7 @@ const DEFAULT_VALUES = {
   referenceLines: [null, null],
   strokeColors: ['#e83a0e', '#ede90c', '#07e345'],
   strokeWidth: 2,
+  centerRadius: 20,
   strokeDashArray: '',
   display: true,
 };
@@ -341,6 +338,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'display',
     'apiIndex',
     'referenceLines',
+    'centerRadius',
   ]);
 
   macro.setGetArray(publicAPI, model, ['point', 'referenceLines'], 2);

--- a/src/VTKViewport/vtkSVGRotatableCrosshairsWidget.js
+++ b/src/VTKViewport/vtkSVGRotatableCrosshairsWidget.js
@@ -45,6 +45,7 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
     // const heightClient = svgContainer.getBoundingClientRect().height;
 
     const p = point.slice();
+
     p[0] = point[0] * scale;
     p[1] = height - point[1] * scale;
 
@@ -56,24 +57,9 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
     // A "far" distance for line clipping algorithm.
     const farDistance = Math.sqrt(bottom * bottom + right * right);
 
-    const lines = [
-      // {
-      //   points: [
-      //     { x: p[0], y: top },
-      //     { x: p[0], y: bottom },
-      //   ],
-      //   color: null,
-      //   apiIndex: null,
-      // },
-      // {
-      //   points: [
-      //     { x: left, y: p[1] },
-      //     { x: right, y: p[1] },
-      //   ],
-      //   color: null,
-      //   apiIndex: null,
-      // },
-    ];
+    // TODO -> Move this calculation logic to the update function
+    // And then save the values so we can grab them with another func.
+    const lines = [];
 
     const thisApi = apis[apiIndex];
 
@@ -83,32 +69,9 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
       'cachedCrosshairWorldPosition'
     );
 
-    // TEMP
-    const viewUpThisApi = thisApi.getViewUp();
-    const sliceNormalThisApi = thisApi.getSliceNormal();
-
-    let xAxisThisApi = [];
-
-    vec3.cross(xAxisThisApi, viewUpThisApi, sliceNormalThisApi);
-    vec3.normalize(xAxisThisApi, xAxisThisApi);
-
-    console.log(`==== THIS API (${apiIndex})=====`);
-
-    console.log(`Center: [${p[0]},${p[1]},${p[2]}]`);
-    console.log(
-      `viewUp: [${viewUpThisApi[0]},${viewUpThisApi[1]},${viewUpThisApi[2]}]`
-    );
-    console.log(
-      `xAxis: [${xAxisThisApi[0]},${xAxisThisApi[1]},${xAxisThisApi[2]}]`
-    );
-
-    // TEMP
-
     for (let i = 0; i < apis.length; i++) {
       if (i !== apiIndex) {
         const api = apis[i];
-
-        console.log(`API ${i}`);
 
         const viewUp = api.getViewUp();
         const sliceNormal = api.getSliceNormal();
@@ -117,10 +80,6 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
 
         vec3.cross(xAxis, viewUp, sliceNormal);
         vec3.normalize(xAxis, xAxis);
-
-        console.log('==== THIS API =====');
-        console.log(`viewUp: [${viewUp[0]},${viewUp[1]},${viewUp[2]}]`);
-        console.log(`xAxis: [${xAxis[0]},${xAxis[1]},${xAxis[2]}]`);
 
         // get a point in the plane.
         // Need a distant world position or we get rounding errors when mapping to screen and don't get nice right angles.
@@ -139,8 +98,6 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
         const doubleDisplayPosition = wPos.getComputedDoubleDisplayValue(
           renderer
         );
-
-        debugger;
 
         let unitVectorFromCenter = [];
         vec2.subtract(unitVectorFromCenter, p, doubleDisplayPosition);
@@ -164,11 +121,9 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
           bottom,
         ]); // returns 1 - "clipped"
 
-        debugger;
         const line = {
           points: [
             { x: negativeDistantPoint[0], y: negativeDistantPoint[1] },
-            // { x: doubleDisplayPosition[0], y: doubleDisplayPosition[1] },
             {
               x: distantPoint[0],
               y: distantPoint[1],
@@ -179,10 +134,6 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
         };
 
         lines.push(line);
-
-        // lines[lineIndex].color = ;
-        // lines[lineIndex].apiIndex = i;
-        //lineIndex++; // Temp to test.
       }
     }
 

--- a/src/VTKViewport/vtkSVGRotatableCrosshairsWidget.js
+++ b/src/VTKViewport/vtkSVGRotatableCrosshairsWidget.js
@@ -152,6 +152,19 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
     const left = 0;
     const bottom = height / scale;
 
+    // split up lines.
+
+    // const p = point.slice();
+
+    // p[0] = point[0] * scale;
+    // p[1] = height - point[1] * scale;
+
+    // debugger;
+
+    // const [firstLine, secondLine] = referenceLines;
+
+    // const firstLineDirection = refer;
+
     if (model.display) {
       node.innerHTML = `
       <g id="container" fill-opacity="1" stroke-dasharray="none" stroke="none" stroke-opacity="1" fill="none">

--- a/src/ViewportOverlay/ViewportOverlay.js
+++ b/src/ViewportOverlay/ViewportOverlay.js
@@ -15,6 +15,7 @@ const {
 class ViewportOverlay extends PureComponent {
   static propTypes = {
     voi: PropTypes.object.isRequired,
+    rotation: PropTypes.object,
     studyDate: PropTypes.string,
     studyTime: PropTypes.string,
     studyDescription: PropTypes.string,
@@ -41,9 +42,15 @@ class ViewportOverlay extends PureComponent {
       seriesNumber,
       seriesDescription,
       voi,
+      rotation,
     } = this.props;
     const { windowWidth, windowCenter } = voi;
     const wwwc = `W: ${windowWidth.toFixed(0)} L: ${windowCenter.toFixed(0)}`;
+    const rotationString = rotation
+      ? `\u03B8: ${rotation.theta.toFixed(1)} \u03D5: ${rotation.phi.toFixed(
+          1
+        )}`
+      : null;
 
     return (
       <div className="ViewportOverlay">
@@ -59,6 +66,7 @@ class ViewportOverlay extends PureComponent {
         </div>
         <div className="bottom-right overlay-element">
           <div>{wwwc}</div>
+          <div>{rotationString}</div>
         </div>
         <div className="bottom-left overlay-element">
           <div>{seriesNumber >= 0 ? `Ser: ${seriesNumber}` : ''}</div>

--- a/src/helpers/liangBarksyClip.js
+++ b/src/helpers/liangBarksyClip.js
@@ -1,0 +1,85 @@
+// Pulled from source: https://github.com/w8r/liang-barsky
+// MIT Licensed.
+
+/**
+ * @preserve
+ * Fast, destructive implemetation of Liang-Barsky line clipping algorithm.
+ * It clips a 2D segment by a rectangle.
+ * @author Alexander Milevski <info@w8r.name>
+ * @license MIT
+ */
+
+const EPSILON = 1e-6;
+const INSIDE = 1;
+const OUTSIDE = 0;
+
+function clipT(num, denom, c) {
+  const [tE, tL] = c;
+  if (Math.abs(denom) < EPSILON) return num < 0;
+  const t = num / denom;
+
+  if (denom > 0) {
+    if (t > tL) return 0;
+    if (t > tE) c[0] = t;
+  } else {
+    if (t < tE) return 0;
+    if (t < tL) c[1] = t;
+  }
+  return 1;
+}
+
+/**
+ * @param  {Point} a
+ * @param  {Point} b
+ * @param  {BoundingBox} box [xmin, ymin, xmax, ymax]
+ * @param  {Point?} [da]
+ * @param  {Point?} [db]
+ * @return {number}
+ */
+export default function clip(a, b, box, da, db) {
+  const [x1, y1] = a;
+  const [x2, y2] = b;
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+
+  if (da === undefined || db === undefined) {
+    da = a;
+    db = b;
+  } else {
+    da[0] = a[0];
+    da[1] = a[1];
+    db[0] = b[0];
+    db[1] = b[1];
+  }
+
+  if (
+    Math.abs(dx) < EPSILON &&
+    Math.abs(dy) < EPSILON &&
+    x1 >= box[0] &&
+    x1 <= box[2] &&
+    y1 >= box[1] &&
+    y1 <= box[3]
+  ) {
+    return INSIDE;
+  }
+
+  const c = [0, 1];
+  if (
+    clipT(box[0] - x1, dx, c) &&
+    clipT(x1 - box[2], -dx, c) &&
+    clipT(box[1] - y1, dy, c) &&
+    clipT(y1 - box[3], -dy, c)
+  ) {
+    const [tE, tL] = c;
+    if (tL < 1) {
+      db[0] = x1 + tL * dx;
+      db[1] = y1 + tL * dy;
+    }
+    if (tE > 0) {
+      da[0] += tE * dx;
+      da[1] += tE * dy;
+    }
+    return INSIDE;
+  }
+  return OUTSIDE;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import View3D from './VTKViewport/View3D';
 import vtkInteractorStyleMPRSlice from './VTKViewport/vtkInteractorStyleMPRSlice.js';
 import vtkInteractorStyleMPRWindowLevel from './VTKViewport/vtkInteractorStyleMPRWindowLevel.js';
 import vtkInteractorStyleMPRCrosshairs from './VTKViewport/vtkInteractorStyleMPRCrosshairs.js';
+import vtkInteractorStyleRotatableMPRCrosshairs from './VTKViewport/vtkInteractorStyleRotatableMPRCrosshairs.js';
 import vtkInteractorStyleMPRRotate from './VTKViewport/vtkInteractorStyleMPRRotate.js';
 import vtkSVGWidgetManager from './VTKViewport/vtkSVGWidgetManager.js';
 import vtkSVGCrosshairsWidget from './VTKViewport/vtkSVGCrosshairsWidget.js';
@@ -22,6 +23,7 @@ export {
   loadImageData,
   vtkInteractorStyleMPRWindowLevel,
   vtkInteractorStyleMPRCrosshairs,
+  vtkInteractorStyleRotatableMPRCrosshairs,
   vtkInteractorStyleMPRRotate,
   vtkInteractorStyleMPRSlice,
   vtkSVGWidgetManager,

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import vtkInteractorStyleRotatableMPRCrosshairs from './VTKViewport/vtkInteracto
 import vtkInteractorStyleMPRRotate from './VTKViewport/vtkInteractorStyleMPRRotate.js';
 import vtkSVGWidgetManager from './VTKViewport/vtkSVGWidgetManager.js';
 import vtkSVGCrosshairsWidget from './VTKViewport/vtkSVGCrosshairsWidget.js';
+import vtkSVGRotatableCrosshairsWidget from './VTKViewport/vtkSVGRotatableCrosshairsWidget.js';
 import ViewportData from './VTKViewport/ViewportData';
 import ViewportOverlay from './ViewportOverlay/ViewportOverlay.js';
 import getImageData from './lib/getImageData.js';
@@ -28,6 +29,7 @@ export {
   vtkInteractorStyleMPRSlice,
   vtkSVGWidgetManager,
   vtkSVGCrosshairsWidget,
+  vtkSVGRotatableCrosshairsWidget,
   invertVolume,
   EVENTS,
 };


### PR DESCRIPTION
This PR adds rotatable crosshairs.

This adds a rotatable crosshair implementation with handles for rotation and draggable lines. You can optionally choose whether to show the angles relative to the original orientation for each viewport.

This does not remove the old crosshair implementation as many are dependent on it.

[Demo link](https://deploy-preview-115--react-vtkjs-viewport.netlify.app/rotatable-crosshairs)