### PR TITLE
Rotatable crosshairs updates

### DIFF
--- a/examples/VTKRotatableCrosshairsExample.js
+++ b/examples/VTKRotatableCrosshairsExample.js
@@ -207,6 +207,17 @@ class VTKRotatableCrosshairsExample extends Component {
     this.setState({ displayCrosshairs: shouldDisplayCrosshairs });
   };
 
+  resetCrosshairs = () => {
+    const apis = this.apis;
+
+    apis.forEach(api => {
+      api.resetOrientation();
+    });
+
+    // Reset the crosshairs
+    apis[0].svgWidgets.rotatableCrosshairsWidget.resetCrosshairs(apis, 0);
+  };
+
   render() {
     if (!this.state.volumes || !this.state.volumes.length) {
       return <h4>Loading...</h4>;
@@ -241,6 +252,7 @@ class VTKRotatableCrosshairsExample extends Component {
                 ? 'Switch To WL/Zoom/Pan/Scroll'
                 : 'Switch To Crosshairs'}
             </button>
+            <button onClick={this.resetCrosshairs}>reset crosshairs</button>
           </div>
         </div>
         <div className="row">

--- a/src/VTKViewport/View2D.js
+++ b/src/VTKViewport/View2D.js
@@ -217,6 +217,7 @@ export default class View2D extends Component {
     const boundUpdateVOI = this.updateVOI.bind(this);
     const boundGetOrienation = this.getOrientation.bind(this);
     const boundSetOrientation = this.setOrientation.bind(this);
+    const boundResetOrientation = this.resetOrientation.bind(this);
     const boundGetViewUp = this.getViewUp.bind(this);
     const boundGetSliceNormal = this.getSliceNormal.bind(this);
     const boundSetInteractorStyle = this.setInteractorStyle.bind(this);
@@ -261,6 +262,7 @@ export default class View2D extends Component {
         updateVOI: boundUpdateVOI,
         getOrientation: boundGetOrienation,
         setOrientation: boundSetOrientation,
+        resetOrientation: boundResetOrientation,
         getViewUp: boundGetViewUp,
         getSliceNormal: boundGetSliceNormal,
         setInteractorStyle: boundSetInteractorStyle,
@@ -305,6 +307,23 @@ export default class View2D extends Component {
     this.updateRotationRelativeToOrientation(sliceNormal);
 
     currentIStyle.setSliceOrientation(sliceNormal, viewUp);
+  }
+
+  resetOrientation() {
+    const orientation = this.props.orientation || {
+      sliceNormal: [0, 0, 1],
+      viewUp: [0, -1, 0],
+    };
+
+    // Reset orientation.
+    this.setOrientation(orientation.sliceNormal, orientation.viewUp);
+
+    // Reset slice.
+    const renderWindow = this.genericRenderWindow.getRenderWindow();
+    const currentIStyle = renderWindow.getInteractor().getInteractorStyle();
+    const range = currentIStyle.getSliceRange();
+
+    currentIStyle.setSlice((range[0] + range[1]) / 2);
   }
 
   getApiProperty(propertyName) {

--- a/src/VTKViewport/vtkInteractorStyleMPRSlice.js
+++ b/src/VTKViewport/vtkInteractorStyleMPRSlice.js
@@ -74,7 +74,7 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
     sliceCenter: [],
   };
 
-  function updateScrollManipulator() {
+  publicAPI.updateScrollManipulator = () => {
     const range = publicAPI.getSliceRange();
     model.scrollManipulator.removeScrollListener();
     // The Scroll listener has min, max, step, and getValue setValue as params.
@@ -86,7 +86,7 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
       publicAPI.getSlice,
       publicAPI.scrollToSlice
     );
-  }
+  };
 
   function setManipulators() {
     publicAPI.removeAllMouseManipulators();
@@ -94,7 +94,7 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
     publicAPI.addMouseManipulator(model.panManipulator);
     publicAPI.addMouseManipulator(model.zoomManipulator);
     publicAPI.addMouseManipulator(model.scrollManipulator);
-    updateScrollManipulator();
+    publicAPI.updateScrollManipulator();
   }
 
   function isCameraViewInitialized(camera) {
@@ -219,7 +219,7 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
       const camera = renderer.getActiveCamera();
 
       cameraSub = camera.onModified(() => {
-        updateScrollManipulator();
+        publicAPI.updateScrollManipulator();
         publicAPI.modified();
       });
 
@@ -328,7 +328,7 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
         setViewUpInternal(viewportData.getCurrentViewUp());
       }
 
-      updateScrollManipulator();
+      publicAPI.updateScrollManipulator();
       // NOTE: Disabling this because it makes it more difficult to switch
       // interactor styles. Need to find a better way to do this!
       //publicAPI.setSliceNormal(...publicAPI.getSliceNormal());

--- a/src/VTKViewport/vtkInteractorStyleMPRSlice.js
+++ b/src/VTKViewport/vtkInteractorStyleMPRSlice.js
@@ -238,7 +238,7 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
   // TODO -> When we want a modular framework we'll have to rethink all this.
   // TODO -> We need to think of a more generic way to do this for all widget types eventually.
   // TODO -> We certainly need to be able to register widget types on instantiation.
-  function handleButtonPress() {
+  function handleButtonPress(callData) {
     const { apis, apiIndex } = model;
 
     if (apis && apis[apiIndex] && apis[apiIndex].type === 'VIEW2D') {
@@ -250,9 +250,31 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
         api.svgWidgets.crosshairsWidget.updateCrosshairForApi(api);
       }
       if (api.svgWidgets.rotatableCrosshairsWidget) {
-        api.svgWidgets.rotatableCrosshairsWidget.updateCrosshairForApi(api);
+        updateRotatableCrosshairs(callData);
       }
     }
+  }
+
+  function updateRotatableCrosshairs(callData) {
+    const { apis, apiIndex } = model;
+    const thisApi = apis[apiIndex];
+    const { rotatableCrosshairsWidget } = thisApi.svgWidgets;
+    const renderer = callData.pokedRenderer;
+    const worldPos = thisApi.get('cachedCrosshairWorldPosition');
+
+    const camera = renderer.getActiveCamera();
+    const directionOfProjection = camera.getDirectionOfProjection();
+
+    const halfSlabThickness = thisApi.getSlabThickness() / 2;
+
+    // Add half of the slab thickness to the world position, such that we select
+    // The center of the slice.
+
+    for (let i = 0; i < worldPos.length; i++) {
+      worldPos[i] += halfSlabThickness * directionOfProjection[i];
+    }
+
+    rotatableCrosshairsWidget.moveCrosshairs(worldPos, apis, apiIndex);
   }
 
   publicAPI.handleMiddleButtonPress = macro.chain(
@@ -280,12 +302,12 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
         api.svgWidgets.crosshairsWidget.updateCrosshairForApi(api);
       }
       if (api.svgWidgets.rotatableCrosshairsWidget) {
-        api.svgWidgets.rotatableCrosshairsWidget.updateCrosshairForApi(api);
+        updateRotatableCrosshairs(callData);
       }
     }
   };
 
-  function handleButtonRelease(superButtonRelease) {
+  function handleButtonRelease(superButtonRelease, callData) {
     if (model.state === States.IS_PAN) {
       publicAPI.endPan();
       const { apis, apiIndex } = model;
@@ -295,7 +317,7 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
         api.svgWidgets.crosshairsWidget.updateCrosshairForApi(api);
       }
       if (api.svgWidgets.rotatableCrosshairsWidget) {
-        api.svgWidgets.rotatableCrosshairsWidget.updateCrosshairForApi(api);
+        updateRotatableCrosshairs(callData);
       }
     }
 
@@ -304,13 +326,13 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
 
   publicAPI.superHandleMiddleButtonRelease =
     publicAPI.handleMiddleButtonRelease;
-  publicAPI.handleMiddleButtonRelease = () => {
-    handleButtonRelease(publicAPI.superHandleMiddleButtonRelease);
+  publicAPI.handleMiddleButtonRelease = callData => {
+    handleButtonRelease(publicAPI.superHandleMiddleButtonRelease, callData);
   };
 
   publicAPI.superHandleRightButtonRelease = publicAPI.handleRightButtonRelease;
-  publicAPI.handleRightButtonRelease = () => {
-    handleButtonRelease(publicAPI.superHandleRightButtonRelease);
+  publicAPI.handleRightButtonRelease = callData => {
+    handleButtonRelease(publicAPI.superHandleRightButtonRelease, callData);
   };
 
   publicAPI.setVolumeActor = actor => {

--- a/src/VTKViewport/vtkInteractorStyleRotatableMPRCrosshairs.js
+++ b/src/VTKViewport/vtkInteractorStyleRotatableMPRCrosshairs.js
@@ -4,6 +4,7 @@ import Constants from 'vtk.js/Sources/Rendering/Core/InteractorStyle/Constants';
 import vtkCoordinate from 'vtk.js/Sources/Rendering/Core/Coordinate';
 import vtkMatrixBuilder from 'vtk.js/Sources/Common/Core/MatrixBuilder';
 import { vec2, vec3, quat } from 'gl-matrix';
+import { HashedModuleIdsPlugin } from 'webpack';
 
 const { States } = Constants;
 
@@ -562,13 +563,48 @@ function vtkInteractorStyleRotatableMPRCrosshairs(publicAPI, model) {
     publicAPI.endWindowLevel();
     publicAPI.endPan();
   }
+
+  publicAPI.updateScrollManipulator = () => {
+    console.log('I HAVE CONTROLL');
+
+    const range = publicAPI.getSliceRange();
+    model.scrollManipulator.removeScrollListener();
+    // The Scroll listener has min, max, step, and getValue setValue as params.
+    // Internally, it checks that the result of the GET has changed, and only calls SET if it is new.
+    model.scrollManipulator.setScrollListener(
+      range[0],
+      range[1],
+      1,
+      publicAPI.getSlice,
+      publicAPI.scrollToSlice
+    );
+  };
+
+  const superScrollToSlice = publicAPI.scrollToSlice;
+  publicAPI.scrollToSlice = slice => {
+    const direction = publicAPI.getSlice() - slice;
+
+    if (!model.disableNormalMPRScroll) {
+      superScrollToSlice(slice);
+    }
+
+    debugger;
+  };
+
+  // publicAPI.scrollToSlice = (slice)  => {
+
+  // }
 }
 
 // ----------------------------------------------------------------------------
 // Object factory
 // ----------------------------------------------------------------------------
 
-const DEFAULT_VALUES = { operation: { type: null }, lineGrabDistance: 20 };
+const DEFAULT_VALUES = {
+  operation: { type: null },
+  lineGrabDistance: 20,
+  disableNormalMPRScroll: true,
+};
 
 // ----------------------------------------------------------------------------
 

--- a/src/VTKViewport/vtkInteractorStyleRotatableMPRCrosshairs.js
+++ b/src/VTKViewport/vtkInteractorStyleRotatableMPRCrosshairs.js
@@ -580,16 +580,14 @@ function vtkInteractorStyleRotatableMPRCrosshairs(publicAPI, model) {
     );
   };
 
-  const superScrollToSlice = publicAPI.scrollToSlice;
-  publicAPI.scrollToSlice = slice => {
-    const direction = publicAPI.getSlice() - slice;
+  // const superScrollToSlice = publicAPI.scrollToSlice;
+  // publicAPI.scrollToSlice = slice => {
+  //   const direction = publicAPI.getSlice() - slice;
 
-    if (!model.disableNormalMPRScroll) {
-      superScrollToSlice(slice);
-    }
-
-    debugger;
-  };
+  //   if (!model.disableNormalMPRScroll)
+  //   superScrollToSlice(slice);
+  //   debugger;
+  // };
 
   // publicAPI.scrollToSlice = (slice)  => {
 

--- a/src/VTKViewport/vtkInteractorStyleRotatableMPRCrosshairs.js
+++ b/src/VTKViewport/vtkInteractorStyleRotatableMPRCrosshairs.js
@@ -702,6 +702,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'onScroll',
     'operation',
     'lineGrabDistance',
+    'disableNormalMPRScroll',
   ]);
 
   // Object specific methods

--- a/src/VTKViewport/vtkInteractorStyleRotatableMPRCrosshairs.js
+++ b/src/VTKViewport/vtkInteractorStyleRotatableMPRCrosshairs.js
@@ -4,7 +4,6 @@ import Constants from 'vtk.js/Sources/Rendering/Core/InteractorStyle/Constants';
 import vtkCoordinate from 'vtk.js/Sources/Rendering/Core/Coordinate';
 import vtkMatrixBuilder from 'vtk.js/Sources/Common/Core/MatrixBuilder';
 import { vec2, vec3, quat } from 'gl-matrix';
-import { HashedModuleIdsPlugin } from 'webpack';
 
 const { States } = Constants;
 

--- a/src/VTKViewport/vtkSVGRotatableCrosshairsWidget.js
+++ b/src/VTKViewport/vtkSVGRotatableCrosshairsWidget.js
@@ -47,6 +47,9 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
 
     const quarterSmallestDimension = Math.min(width, height) / 4;
 
+    const halfWidth = width / 2;
+    const halfHeight = height / 2;
+
     // A "far" distance for line clipping algorithm.
     const farDistance = Math.sqrt(bottom * bottom + right * right);
 
@@ -170,7 +173,6 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
     let {
       point,
       strokeColors,
-      activeStrokeColors,
       strokeWidth,
       strokeDashArray,
       apis,
@@ -318,7 +320,7 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
         secondLineRotateHandles[1].y
       }" r="10" fill="none" />
       </g>
-      <circle cx="${bottom - 20}" cy="${left + 20}" r="10" fill="${
+      <circle cx="${width - 20}" cy="${20}" r="10" fill="${
         strokeColors[apiIndex]
       }" />
       </g>
@@ -485,8 +487,6 @@ const DEFAULT_VALUES = {
   apis: [null, null, null],
   referenceLines: [null, null],
   strokeColors: ['#e83a0e', '#ede90c', '#07e345'],
-  //activeStrokeColors: ['#e66343', '#ebe978', '#78de95'],
-  activeStrokeColors: ['#ffffff', '#ffffff', '#ffffff'],
   strokeWidth: 2,
   selectedStrokeWidth: 5,
   centerRadius: 20,
@@ -512,12 +512,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   ]);
 
   macro.setGetArray(publicAPI, model, ['point', 'referenceLines'], 2);
-  macro.setGetArray(
-    publicAPI,
-    model,
-    ['apis', 'strokeColors', 'activeStrokeColors'],
-    3
-  );
+  macro.setGetArray(publicAPI, model, ['apis', 'strokeColors'], 3);
 
   vtkSVGRotatableCrosshairsWidget(publicAPI, model);
 }

--- a/src/VTKViewport/vtkSVGRotatableCrosshairsWidget.js
+++ b/src/VTKViewport/vtkSVGRotatableCrosshairsWidget.js
@@ -119,10 +119,12 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
 
         let lineSelected = false;
         let rotateSelected = false;
+        let lineActive = false;
 
         if (oldReferenceLine) {
           lineSelected = oldReferenceLine.selected;
           rotateSelected = oldReferenceLine.rotateHandles.selected;
+          lineActive = oldReferenceLine.active;
         }
 
         const firstRotateHandle = {
@@ -150,6 +152,7 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
           color: strokeColors[i],
           apiIndex: i,
           selected: lineSelected,
+          active: lineActive,
         };
 
         referenceLines.push(referenceLine);
@@ -167,6 +170,7 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
     let {
       point,
       strokeColors,
+      activeStrokeColors,
       strokeWidth,
       strokeDashArray,
       apis,
@@ -213,12 +217,17 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
       p
     );
 
-    const firstLineStrokeWidth = firstLine.selected
-      ? selectedStrokeWidth
-      : strokeWidth;
-    const secondLineStrokeWidth = secondLine.selected
-      ? selectedStrokeWidth
-      : strokeWidth;
+    const firstLineStrokeColor = strokeColors[firstLine.apiIndex];
+    const secondLineStrokeColor = strokeColors[secondLine.apiIndex];
+
+    const firstLineStrokeWidth =
+      firstLine.selected || firstLine.active
+        ? selectedStrokeWidth
+        : strokeWidth;
+    const secondLineStrokeWidth =
+      secondLine.selected || secondLine.active
+        ? selectedStrokeWidth
+        : strokeWidth;
 
     const firstLineRotateWidth = firstLineRotateSelected
       ? selectedStrokeWidth
@@ -234,7 +243,7 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
        <svg version="1.1" viewBox="0 0 ${width} ${height}" width=${width} height=${height} style="width: 100%; height: 100%">
         <g
 
-          stroke="${referenceLines[0].color}"
+          stroke="${firstLineStrokeColor}"
           stroke-dasharray="${strokeDashArray}"
           stroke-linecap="round"
           stroke-linejoin="round"
@@ -273,7 +282,7 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
         </g>
         <g
           stroke-dasharray="${strokeDashArray}"
-          stroke="${referenceLines[1].color}"
+          stroke="${secondLineStrokeColor}"
           stroke-linecap="round"
           stroke-linejoin="round"
           stroke-width=${secondLineStrokeWidth}
@@ -476,6 +485,8 @@ const DEFAULT_VALUES = {
   apis: [null, null, null],
   referenceLines: [null, null],
   strokeColors: ['#e83a0e', '#ede90c', '#07e345'],
+  //activeStrokeColors: ['#e66343', '#ebe978', '#78de95'],
+  activeStrokeColors: ['#ffffff', '#ffffff', '#ffffff'],
   strokeWidth: 2,
   selectedStrokeWidth: 5,
   centerRadius: 20,
@@ -501,7 +512,12 @@ export function extend(publicAPI, model, initialValues = {}) {
   ]);
 
   macro.setGetArray(publicAPI, model, ['point', 'referenceLines'], 2);
-  macro.setGetArray(publicAPI, model, ['apis', 'strokeColors'], 3);
+  macro.setGetArray(
+    publicAPI,
+    model,
+    ['apis', 'strokeColors', 'activeStrokeColors'],
+    3
+  );
 
   vtkSVGRotatableCrosshairsWidget(publicAPI, model);
 }


### PR DESCRIPTION
This fixes:
- Pan.
- Adds an api to reset the orientation/crosshairs + added that to the demo.
- Placement of the color reference indicator for non-square viewports.

This adds:
- Adds the ability to select a reference line then use the mouse wheel to scroll it.
- Adds the option to disable normal scroll when crosshairs are on (default off).