### PR TITLE
fix: 🐛 SVG orientation fix

### DIFF
--- a/examples/VTKRotatableCrosshairsExample.js
+++ b/examples/VTKRotatableCrosshairsExample.js
@@ -13,10 +13,12 @@ import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
 import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
 
 const url = 'https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs';
+
 const studyInstanceUID =
-  '1.3.6.1.4.1.14519.5.2.1.2744.7002.373729467545468642229382466905';
-const ctSeriesInstanceUID =
-  '1.3.6.1.4.1.14519.5.2.1.2744.7002.182837959725425690842769990419';
+  '1.3.12.2.1107.5.2.32.35162.30000015050317233592200000046';
+const mrSeriesInstanceUID =
+  '1.3.12.2.1107.5.2.32.35162.1999123112191238897317963.0.0.0';
+
 const searchInstanceOptions = {
   studyInstanceUID,
 };
@@ -74,7 +76,7 @@ class VTKRotatableCrosshairsExample extends Component {
     const imageIds = await createStudyImageIds(url, searchInstanceOptions);
 
     let ctImageIds = imageIds.filter(imageId =>
-      imageId.includes(ctSeriesInstanceUID)
+      imageId.includes(mrSeriesInstanceUID)
     );
 
     const ctImageDataObject = loadDataset(ctImageIds, 'ctDisplaySet');

--- a/src/VTKViewport/vtkInteractorStyleRotatableMPRCrosshairs.js
+++ b/src/VTKViewport/vtkInteractorStyleRotatableMPRCrosshairs.js
@@ -214,7 +214,7 @@ function vtkInteractorStyleRotatableMPRCrosshairs(publicAPI, model) {
       pointToNewPosition[0] * pointToPreviousPosition[1] -
       pointToNewPosition[1] * pointToPreviousPosition[0];
 
-    if (determinant < 0) {
+    if (determinant > 0) {
       angle *= -1;
     }
 

--- a/src/VTKViewport/vtkSVGRotatableCrosshairsWidget.js
+++ b/src/VTKViewport/vtkSVGRotatableCrosshairsWidget.js
@@ -47,9 +47,6 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
 
     const quarterSmallestDimension = Math.min(width, height) / 4;
 
-    const halfWidth = width / 2;
-    const halfHeight = height / 2;
-
     // A "far" distance for line clipping algorithm.
     const farDistance = Math.sqrt(bottom * bottom + right * right);
 
@@ -95,8 +92,15 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
           renderer
         );
 
+        // convert to svg coordinates:
+
+        const doubleSVGPosition = [
+          doubleDisplayPosition[0] * scale,
+          height - doubleDisplayPosition[1] * scale,
+        ];
+
         let unitVectorFromCenter = [];
-        vec2.subtract(unitVectorFromCenter, p, doubleDisplayPosition);
+        vec2.subtract(unitVectorFromCenter, p, doubleSVGPosition);
         vec2.normalize(unitVectorFromCenter, unitVectorFromCenter);
 
         const distantPoint = [


### PR DESCRIPTION
- The reference lines where inverted with respect to the canvas, due to not accounting for a switch from displayCoordinates to SVG, causing a clockwise rotation to map to an anti-clockwise rotation.
- Fixed this issue.
- Changed the rotatable crosshairs example to use a head scan, which makes it much easier to identify such issues.