### PR TITLE
fix: 🐛 Make crosshair handle thickness configurable. fix bug

### DIFF
--- a/src/VTKViewport/vtkInteractorStyleRotatableMPRCrosshairs.js
+++ b/src/VTKViewport/vtkInteractorStyleRotatableMPRCrosshairs.js
@@ -437,6 +437,39 @@ function vtkInteractorStyleRotatableMPRCrosshairs(publicAPI, model) {
       p[1] + unitVector[1] * displayCoordintateScrollIncrement,
     ];
 
+    // Clip to box defined by the crosshairs extent
+
+    let lowX;
+    let highX;
+    let lowY;
+    let highY;
+
+    if (lowToHighPoints[0].x < lowToHighPoints[1].x) {
+      lowX = lowToHighPoints[0].x;
+      highX = lowToHighPoints[1].x;
+    } else {
+      lowX = lowToHighPoints[1].x;
+      highX = lowToHighPoints[0].x;
+    }
+
+    if (lowToHighPoints[0].y < lowToHighPoints[1].y) {
+      lowY = lowToHighPoints[0].y;
+      highY = lowToHighPoints[1].y;
+    } else {
+      lowY = lowToHighPoints[1].y;
+      highY = lowToHighPoints[0].y;
+    }
+
+    newCenterPointSVG[0] = Math.min(
+      Math.max(newCenterPointSVG[0], lowX),
+      highX
+    );
+
+    newCenterPointSVG[1] = Math.min(
+      Math.max(newCenterPointSVG[1], lowY),
+      highY
+    );
+
     // translate to the display coordinates.
     const displayCoordinate = {
       x: newCenterPointSVG[0] / scale,

--- a/src/VTKViewport/vtkSVGRotatableCrosshairsWidget.js
+++ b/src/VTKViewport/vtkSVGRotatableCrosshairsWidget.js
@@ -179,6 +179,7 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
       strokeColors,
       strokeWidth,
       strokeDashArray,
+      rotateHandleRadius,
       apis,
       apiIndex,
       selectedStrokeWidth,
@@ -242,6 +243,19 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
       ? selectedStrokeWidth
       : strokeWidth;
 
+    const firstLineShowCrosshairs =
+      firstLine.selected || firstLineRotateSelected;
+    const secondLineShowCrosshairs =
+      secondLine.selected || secondLineRotateSelected;
+
+    const firstLineRotateHandleRadius = firstLineShowCrosshairs
+      ? rotateHandleRadius
+      : 0;
+
+    const secondLineRotateHandleRadius = secondLineShowCrosshairs
+      ? rotateHandleRadius
+      : 0;
+
     if (model.display) {
       node.innerHTML = `
       <g id="container" fill-opacity="1" stroke-dasharray="none" stroke="none" stroke-opacity="1" fill="none">
@@ -280,11 +294,11 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
             <!--First line rotateHandle 0 -->
             <circle cx="${firstLineRotateHandles[0].x}" cy="${
         firstLineRotateHandles[0].y
-      }" r="10" fill="none" />
+      }" r="${firstLineRotateHandleRadius}" fill="none" />
             <!--First line rotateHandle 1 -->
             <circle cx="${firstLineRotateHandles[1].x}" cy="${
         firstLineRotateHandles[1].y
-      }" r="10" fill="none" />
+      }" r="${firstLineRotateHandleRadius}" fill="none" />
         </g>
         <g
           stroke-dasharray="${strokeDashArray}"
@@ -318,11 +332,11 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
         <!--Second line rotateHandle 0 -->
         <circle cx="${secondLineRotateHandles[0].x}" cy="${
         secondLineRotateHandles[0].y
-      }" r="10" fill="none" />
+      }" r="${secondLineRotateHandleRadius}" fill="none" />
         <!--Second line rotateHandle 1 -->
         <circle cx="${secondLineRotateHandles[1].x}" cy="${
         secondLineRotateHandles[1].y
-      }" r="10" fill="none" />
+      }" r="${secondLineRotateHandleRadius}" fill="none" />
       </g>
       <circle cx="${width - 20}" cy="${20}" r="10" fill="${
         strokeColors[apiIndex]
@@ -491,8 +505,9 @@ const DEFAULT_VALUES = {
   apis: [null, null, null],
   referenceLines: [null, null],
   strokeColors: ['#e83a0e', '#ede90c', '#07e345'],
-  strokeWidth: 2,
-  selectedStrokeWidth: 5,
+  strokeWidth: 1,
+  rotateHandleRadius: 5,
+  selectedStrokeWidth: 3,
   centerRadius: 20,
   strokeDashArray: '',
   display: true,

--- a/src/VTKViewport/vtkSVGRotatableCrosshairsWidget.js
+++ b/src/VTKViewport/vtkSVGRotatableCrosshairsWidget.js
@@ -256,6 +256,14 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
       ? rotateHandleRadius
       : 0;
 
+    const firstLineRotateHandleFill = firstLineRotateSelected
+      ? referenceLines[0].color
+      : 'none';
+
+    const secondLineRotateHandleFill = secondLineRotateSelected
+      ? referenceLines[1].color
+      : 'none';
+
     if (model.display) {
       node.innerHTML = `
       <g id="container" fill-opacity="1" stroke-dasharray="none" stroke="none" stroke-opacity="1" fill="none">
@@ -294,11 +302,11 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
             <!--First line rotateHandle 0 -->
             <circle cx="${firstLineRotateHandles[0].x}" cy="${
         firstLineRotateHandles[0].y
-      }" r="${firstLineRotateHandleRadius}" fill="none" />
+      }" r="${firstLineRotateHandleRadius}" fill="${firstLineRotateHandleFill}" />
             <!--First line rotateHandle 1 -->
             <circle cx="${firstLineRotateHandles[1].x}" cy="${
         firstLineRotateHandles[1].y
-      }" r="${firstLineRotateHandleRadius}" fill="none" />
+      }" r="${firstLineRotateHandleRadius}" fill="${firstLineRotateHandleFill}" />
         </g>
         <g
           stroke-dasharray="${strokeDashArray}"
@@ -332,11 +340,11 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
         <!--Second line rotateHandle 0 -->
         <circle cx="${secondLineRotateHandles[0].x}" cy="${
         secondLineRotateHandles[0].y
-      }" r="${secondLineRotateHandleRadius}" fill="none" />
+      }" r="${secondLineRotateHandleRadius}" fill="${secondLineRotateHandleFill}" />
         <!--Second line rotateHandle 1 -->
         <circle cx="${secondLineRotateHandles[1].x}" cy="${
         secondLineRotateHandles[1].y
-      }" r="${secondLineRotateHandleRadius}" fill="none" />
+      }" r="${secondLineRotateHandleRadius}" fill="${secondLineRotateHandleFill}" />
       </g>
       <circle cx="${width - 20}" cy="${20}" r="10" fill="${
         strokeColors[apiIndex]


### PR DESCRIPTION
- Crosshairs thinner
- Rotate handle smaller
- Rotate handle only appears on mouse over of the line/handle, or during rotation.
- You can no longer scroll the crosshairs offscreen.