### PR TITLE
Updates in Windowing interactor to avoid rounding in mouse delta calculation

### DIFF
--- a/src/VTKViewport/vtkInteractorStyleMPRWindowLevel.js
+++ b/src/VTKViewport/vtkInteractorStyleMPRWindowLevel.js
@@ -42,8 +42,7 @@ function vtkInteractorStyleMPRWindowLevel(publicAPI, model) {
       .getScalars()
       .getRange();
     const imageDynamicRange = range[1] - range[0];
-    const multiplier =
-      Math.round(imageDynamicRange / 1024) * publicAPI.getLevelScale();
+    const multiplier = (imageDynamicRange / 1024) * publicAPI.getLevelScale();
     const dx = Math.round((pos[0] - model.wlStartPos[0]) * multiplier);
     const dy = Math.round((pos[1] - model.wlStartPos[1]) * multiplier);
 


### PR DESCRIPTION
Updates in Windowing interactor to avoid rounding in mouse delta calculation to properly update windowing values on mouse move in small pixel range images like PET.
This is because, if the image pixel range is small, "imageDynamicRange / 1024" will be less than 0.5 and while rounding it becomes zero. This causes Windowing values never change for this image with mouse movement.
This PR can resolve the issue https://github.com/OHIF/react-vtkjs-viewport/issues/136