### PR TITLE
fix: various demos that were using old dcmjs study uids

### DIFF
--- a/examples/VTKCrosshairsExample.js
+++ b/examples/VTKCrosshairsExample.js
@@ -13,9 +13,9 @@ import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
 
 const url = 'https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs';
 const studyInstanceUID =
-  '1.3.6.1.4.1.14519.5.2.1.2744.7002.373729467545468642229382466905';
+  '1.3.6.1.4.1.14519.5.2.1.7009.2403.334240657131972136850343327463';
 const ctSeriesInstanceUID =
-  '1.3.6.1.4.1.14519.5.2.1.2744.7002.182837959725425690842769990419';
+  '1.3.6.1.4.1.14519.5.2.1.7009.2403.226151125820845824875394858561';
 const searchInstanceOptions = {
   studyInstanceUID,
 };

--- a/examples/VTKFusionExample.js
+++ b/examples/VTKFusionExample.js
@@ -15,11 +15,11 @@ window.cornerstoneWADOImageLoader = cornerstoneWADOImageLoader;
 
 const url = 'https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs';
 const studyInstanceUID =
-  '1.3.6.1.4.1.14519.5.2.1.2744.7002.373729467545468642229382466905';
+  '1.3.6.1.4.1.14519.5.2.1.7009.2403.334240657131972136850343327463';
 const ctSeriesInstanceUID =
-  '1.3.6.1.4.1.14519.5.2.1.2744.7002.182837959725425690842769990419';
+  '1.3.6.1.4.1.14519.5.2.1.7009.2403.226151125820845824875394858561';
 const petSeriesInstanceUID =
-  '1.3.6.1.4.1.14519.5.2.1.2744.7002.886851941687931416391879144903';
+  '1.3.6.1.4.1.14519.5.2.1.7009.2403.879445243400782656317561081015';
 const searchInstanceOptions = {
   studyInstanceUID,
 };

--- a/examples/VTKMPRRotateExample.js
+++ b/examples/VTKMPRRotateExample.js
@@ -12,21 +12,6 @@ import './initCornerstone.js';
 
 window.cornerstoneWADOImageLoader = cornerstoneWADOImageLoader;
 
-//const url = 'http://localhost:44301/wadors'
-//const url = 'http://localhost:8080/dcm4chee-arc/aets/DCM4CHEE/rs'
-//const url = 'https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs';
-//const studyInstanceUID =
-// '1.3.6.1.4.1.14519.5.2.1.2744.7002.271803936741289691489150315969';
-//  '1.3.6.1.4.1.14519.5.2.1.2744.7002.373729467545468642229382466905';
-//const ctSeriesInstanceUID =
-// '1.3.6.1.4.1.14519.5.2.1.2744.7002.453958960749354309542907936863'
-//  '1.3.6.1.4.1.14519.5.2.1.2744.7002.182837959725425690842769990419';
-//const petSeriesInstanceUID =
-//  '1.3.6.1.4.1.14519.5.2.1.2744.7002.117357550898198415937979788256';
-//const searchInstanceOptions = {
-//  studyInstanceUID,
-//};
-
 const voi = {
   windowWidth: 1000,
   windowCenter: 300 + 1024,

--- a/examples/VTKRotatableCrosshairsExample.js
+++ b/examples/VTKRotatableCrosshairsExample.js
@@ -15,9 +15,9 @@ import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
 const url = 'https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs';
 
 const studyInstanceUID =
-  '1.3.12.2.1107.5.2.32.35162.30000015050317233592200000046';
-const mrSeriesInstanceUID =
-  '1.3.12.2.1107.5.2.32.35162.1999123112191238897317963.0.0.0';
+  '1.3.6.1.4.1.14519.5.2.1.7009.2403.334240657131972136850343327463';
+const ctSeriesInstanceUID =
+  '1.3.6.1.4.1.14519.5.2.1.7009.2403.226151125820845824875394858561';
 
 const searchInstanceOptions = {
   studyInstanceUID,
@@ -76,7 +76,7 @@ class VTKRotatableCrosshairsExample extends Component {
     const imageIds = await createStudyImageIds(url, searchInstanceOptions);
 
     let ctImageIds = imageIds.filter(imageId =>
-      imageId.includes(mrSeriesInstanceUID)
+      imageId.includes(ctSeriesInstanceUID)
     );
 
     const ctImageDataObject = loadDataset(ctImageIds, 'ctDisplaySet');

--- a/examples/VTKVolumeRenderingExample.js
+++ b/examples/VTKVolumeRenderingExample.js
@@ -15,9 +15,10 @@ window.cornerstoneWADOImageLoader = cornerstoneWADOImageLoader;
 
 const url = 'https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs';
 const studyInstanceUID =
-  '1.3.6.1.4.1.14519.5.2.1.2744.7002.373729467545468642229382466905';
+  '1.3.6.1.4.1.14519.5.2.1.7009.2403.334240657131972136850343327463';
 const ctSeriesInstanceUID =
-  '1.3.6.1.4.1.14519.5.2.1.2744.7002.182837959725425690842769990419';
+  '1.3.6.1.4.1.14519.5.2.1.7009.2403.226151125820845824875394858561';
+
 const searchInstanceOptions = {
   studyInstanceUID,
 };


### PR DESCRIPTION
Demos were broken since they were using old dcmjs server studies

a broken demo: https://react-vtkjs-viewport.netlify.app/volume-rendering