### PR TITLE
Updates to skip transformation calculation when slice normal of the v…

### DIFF
--- a/src/VTKViewport/vtkSVGCrosshairsWidget.js
+++ b/src/VTKViewport/vtkSVGCrosshairsWidget.js
@@ -1,6 +1,9 @@
 import macro from 'vtk.js/Sources/macro';
 import vtkMatrixBuilder from 'vtk.js/Sources/Common/Core/MatrixBuilder';
 import vtkCoordinate from 'vtk.js/Sources/Rendering/Core/Coordinate';
+import { helpers } from '../helpers/index';
+
+const { isAntiParallel } = helpers;
 
 let instanceId = 1;
 
@@ -158,13 +161,20 @@ function vtkSVGCrosshairsWidget(publicAPI, model) {
 
       const istyle = renderWindow.getInteractor().getInteractorStyle();
       const sliceNormal = istyle.getSliceNormal();
-      const transform = vtkMatrixBuilder
-        .buildFromDegree()
-        .identity()
-        .rotateFromDirections(sliceNormal, [1, 0, 0]);
 
       const mutatedWorldPos = worldPos.slice();
-      transform.apply(mutatedWorldPos);
+
+      // Special handling if sliceNormal is [-1,0,0] as rotateFromDirections returns zero matrix.
+      if (isAntiParallel(sliceNormal, [1, 0, 0])) {
+        mutatedWorldPos[0] = mutatedWorldPos[0] * -1;
+      } else {
+        const transform = vtkMatrixBuilder
+          .buildFromDegree()
+          .identity()
+          .rotateFromDirections(sliceNormal, [1, 0, 0]);
+        transform.apply(mutatedWorldPos);
+      }
+
       const slice = mutatedWorldPos[0];
 
       istyle.setSlice(slice);

--- a/src/VTKViewport/vtkSVGRotatableCrosshairsWidget.js
+++ b/src/VTKViewport/vtkSVGRotatableCrosshairsWidget.js
@@ -4,6 +4,9 @@ import vtkCoordinate from 'vtk.js/Sources/Rendering/Core/Coordinate';
 import liangBarksyClip from '../helpers/liangBarksyClip';
 import { vec2, vec3 } from 'gl-matrix';
 import { projectVector2D } from 'vtk.js/Sources/Common/Core/Math';
+import { helpers } from '../helpers/index';
+
+const { isAntiParallel } = helpers;
 
 let instanceId = 1;
 
@@ -441,13 +444,20 @@ function vtkSVGRotatableCrosshairsWidget(publicAPI, model) {
 
       const istyle = renderWindow.getInteractor().getInteractorStyle();
       const sliceNormal = istyle.getSliceNormal();
-      const transform = vtkMatrixBuilder
-        .buildFromDegree()
-        .identity()
-        .rotateFromDirections(sliceNormal, [1, 0, 0]);
 
       const mutatedWorldPos = worldPos.slice();
-      transform.apply(mutatedWorldPos);
+
+      // Special handling if sliceNormal is [-1,0,0] as rotateFromDirections returns zero matrix.
+      if (isAntiParallel(sliceNormal, [1, 0, 0])) {
+        mutatedWorldPos[0] = mutatedWorldPos[0] * -1;
+      } else {
+        const transform = vtkMatrixBuilder
+          .buildFromDegree()
+          .identity()
+          .rotateFromDirections(sliceNormal, [1, 0, 0]);
+        transform.apply(mutatedWorldPos);
+      }
+
       const slice = mutatedWorldPos[0];
 
       istyle.setSlice(slice);

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -3,6 +3,7 @@ import formatDA from './formatDA';
 import formatTM from './formatTM';
 import formatNumberPrecision from './formatNumberPrecision';
 import isValidNumber from './isValidNumber';
+import isAntiParallel from './isAntiParallel';
 import uuidv4 from './uuidv4.js';
 
 const helpers = {
@@ -11,6 +12,7 @@ const helpers = {
   formatTM,
   formatNumberPrecision,
   isValidNumber,
+  isAntiParallel,
 };
 
 export { helpers, uuidv4 };

--- a/src/helpers/isAntiParallel.js
+++ b/src/helpers/isAntiParallel.js
@@ -1,0 +1,7 @@
+import { vec3 } from 'gl-matrix';
+
+export default function isAntiParallel(originalVector, referenceVector) {
+  vec3.normalize(originalVector, originalVector);
+  vec3.normalize(referenceVector, referenceVector);
+  return vec3.dot(originalVector, referenceVector) === -1;
+}


### PR DESCRIPTION
Updates to skip the transformation calculation when slice normal of the viewport api is in negative x direction([-1, 0, 0]).
This is required as zero-transformation matrix is returned when 'rotateFromDirections' function is called with viewport slice normal as negative x-axis([-1,0,0]) and target direction as positive x-axis ([1, 0, 0])
