### PR TITLE
Fix crash when upgrade vtk.js to newer version

### DIFF
--- a/src/VTKViewport/View2D.js
+++ b/src/VTKViewport/View2D.js
@@ -83,7 +83,9 @@ export default class View2D extends Component {
     const normal = camera.getDirectionOfProjection();
     manip.setNormal(...normal);
     manip.setOrigin(...camera.getFocalPoint());
-    handle.rotateFromDirections(handle.getDirection(), normal);
+    if (handle?.rotateFromDirections) {
+      handle.rotateFromDirections(handle.getDirection(), normal);
+    }
   }
 
   componentDidMount() {


### PR DESCRIPTION
When upgrading vtk.js to the newer version (>= 15.0.0). View2D component crash because:
TypeError: handle.rotateFromDirections is not a function.
So I think we should check if rotateFromDirections exists before executing that code.